### PR TITLE
feat: handle exception

### DIFF
--- a/src/main/java/com/zerobase/zbcharger/domain/member/entity/EmailVerification.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/member/entity/EmailVerification.java
@@ -1,8 +1,13 @@
 package com.zerobase.zbcharger.domain.member.entity;
 
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.ALREADY_EMAIL_VERIFIED;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.EMAIL_VERIFICATION_EXPIRED;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.EMAIL_VERIFICATION_RESEND_TIME_EXCEED;
+
 import com.zerobase.zbcharger.domain.common.entity.AuditableEntity;
 import com.zerobase.zbcharger.domain.member.event.EmailVerificationSendEvent;
 import com.zerobase.zbcharger.event.Events;
+import com.zerobase.zbcharger.exception.CustomException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -87,8 +92,7 @@ public class EmailVerification extends AuditableEntity {
      */
     private void alreadyVerified() {
         if (isVerifiedYn()) {
-            // TODO: 커스텀 예외
-            throw new RuntimeException("already verified");
+            throw new CustomException(ALREADY_EMAIL_VERIFIED);
         }
     }
 
@@ -97,8 +101,7 @@ public class EmailVerification extends AuditableEntity {
      */
     private void checkRetryTime() {
         if (lastSentAt != null && LocalDateTime.now().isAfter(lastSentAt.plusMinutes(RETRY_MIN))) {
-            // TODO: 커스텀 예외
-            throw new RuntimeException("retry disable");
+            throw new CustomException(EMAIL_VERIFICATION_RESEND_TIME_EXCEED);
         }
     }
 
@@ -107,8 +110,7 @@ public class EmailVerification extends AuditableEntity {
      */
     private void checkExpiredAt() {
         if (expiredAt != null && LocalDateTime.now().isAfter(expiredAt)) {
-            // TODO: 커스텀 예외
-            throw new RuntimeException("expired");
+            throw new CustomException(EMAIL_VERIFICATION_EXPIRED);
         }
     }
 

--- a/src/main/java/com/zerobase/zbcharger/domain/member/service/EmailVerificationService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/member/service/EmailVerificationService.java
@@ -1,7 +1,10 @@
 package com.zerobase.zbcharger.domain.member.service;
 
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.EMAIL_VERIFICATION_NOT_FOUND;
+
 import com.zerobase.zbcharger.domain.member.dao.EmailVerificationRepository;
 import com.zerobase.zbcharger.domain.member.entity.EmailVerification;
+import com.zerobase.zbcharger.exception.CustomException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import java.util.UUID;
@@ -89,10 +92,9 @@ public class EmailVerificationService {
      */
     @Transactional
     public void verifyEmail(UUID token, String email) {
-        // TODO: 커스텀 예외
         EmailVerification emailVerification = emailVerificationRepository
             .findByIdAndMemberEmail(token, email)
-            .orElseThrow(() -> new RuntimeException("not found"));
+            .orElseThrow(() -> new CustomException(EMAIL_VERIFICATION_NOT_FOUND));
 
         emailVerification.verify();
     }

--- a/src/main/java/com/zerobase/zbcharger/domain/member/service/RegisterMemberService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/member/service/RegisterMemberService.java
@@ -1,10 +1,13 @@
 package com.zerobase.zbcharger.domain.member.service;
 
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.EMAIL_ALREADY_EXISTS;
+
 import com.zerobase.zbcharger.domain.member.dao.EmailVerificationRepository;
 import com.zerobase.zbcharger.domain.member.dao.MemberRepository;
 import com.zerobase.zbcharger.domain.member.dto.RegisterMemberRequest;
 import com.zerobase.zbcharger.domain.member.entity.EmailVerification;
 import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -28,7 +31,7 @@ public class RegisterMemberService {
     @Transactional
     public void registerMember(RegisterMemberRequest request) {
         if (memberRepository.existsByEmail(request.email())) {
-            throw new RuntimeException("중복 이메일 존재");
+            throw new CustomException(EMAIL_ALREADY_EXISTS);
         }
 
         Member member = memberRepository.save(createMember(request));

--- a/src/main/java/com/zerobase/zbcharger/exception/CustomException.java
+++ b/src/main/java/com/zerobase/zbcharger/exception/CustomException.java
@@ -1,0 +1,12 @@
+package com.zerobase.zbcharger.exception;
+
+import com.zerobase.zbcharger.exception.constant.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/zerobase/zbcharger/exception/constant/ErrorCode.java
+++ b/src/main/java/com/zerobase/zbcharger/exception/constant/ErrorCode.java
@@ -1,0 +1,38 @@
+package com.zerobase.zbcharger.exception.constant;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 에러 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    EMAIL_ALREADY_EXISTS(CONFLICT, "중복되는 메일이 존재합니다."),
+
+    EMAIL_VERIFICATION_NOT_FOUND(NOT_FOUND, "이메일 인증 정보를 찾을 수 없습니다."),
+
+    ALREADY_EMAIL_VERIFIED(BAD_REQUEST, "인증이 완료된 요청입니다."),
+    EMAIL_VERIFICATION_EXPIRED(BAD_REQUEST, "인증 시간이 만료됐습니다. 인증 메일을 재발송하세요."),
+    EMAIL_VERIFICATION_RESEND_TIME_EXCEED(BAD_REQUEST, "인증 메일 재전송 가능시간을 초과했습니다. 잠시후 다시 시도하세요."),
+    ARGUMENT_NOT_VALID(BAD_REQUEST, "잘못된 입력입니다."),
+
+    UNHANDLED_ERROR(INTERNAL_SERVER_ERROR, "정의되지 않은 에러 발생");
+
+    /**
+     * 응답 상태
+     */
+    private final HttpStatus status;
+
+    /**
+     * 메시지
+     */
+    private final String message;
+}

--- a/src/main/java/com/zerobase/zbcharger/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/zerobase/zbcharger/exception/dto/ErrorResponse.java
@@ -1,0 +1,113 @@
+package com.zerobase.zbcharger.exception.dto;
+
+import com.zerobase.zbcharger.exception.constant.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.validation.method.ParameterValidationResult;
+
+/**
+ * 에러 응답
+ */
+@Getter
+public class ErrorResponse {
+
+    /**
+     * 요청 경로
+     */
+    private final String path;
+
+    /**
+     * 상태
+     */
+    private final int status;
+
+    /**
+     * 메시지
+     */
+    private final String message;
+
+    /**
+     * 코드
+     */
+    private final ErrorCode code;
+
+    /**
+     * 필드 에러
+     */
+    private final List<Object> errors;
+
+    private ErrorResponse(String path, ErrorCode code) {
+        this.path = path;
+        this.code = code;
+        this.status = code.getStatus().value();
+        this.message = code.getMessage();
+        this.errors = new ArrayList<>();
+    }
+
+    private ErrorResponse(String path, ErrorCode code,
+        List<org.springframework.validation.FieldError> errors) {
+        this(path, code);
+
+        if (errors != null) {
+            this.errors.addAll(
+                errors
+                    .stream()
+                    .map(m -> new FieldError(m.getField(), m.getDefaultMessage()))
+                    .toList()
+            );
+        }
+    }
+
+//    private ErrorResponse(String path, ErrorCode code,
+//        List<ParameterValidationResult> errors) {
+//        this(path, code);
+//
+//        if (errors != null) {
+////            this.errors.addAll(
+////                errors
+////                    .stream()
+////                    .map(m -> new FieldError(m.getField(), m.getDefaultMessage()))
+////                    .toList()
+////            );
+//        }
+//    }
+
+    public static ErrorResponse of(String path, ErrorCode code) {
+        return new ErrorResponse(path, code);
+    }
+
+    public static ErrorResponse of(String path,
+        ErrorCode code,
+        List<org.springframework.validation.FieldError> errors) {
+        return new ErrorResponse(path, code, errors);
+    }
+
+//    public static ErrorResponse of(String path,
+//        ErrorCode code,
+//        List<ParameterValidationResult> errors) {
+//        return new ErrorResponse(path, code, errors);
+//    }
+
+    /**
+     * 필드 에러
+     */
+    @Getter
+    public static class FieldError {
+
+        /**
+         * 필드명
+         */
+        private final String field;
+
+        /**
+         * 에러 메시지
+         */
+        private final String reason;
+
+        private FieldError(String field, String reason) {
+            this.field = field;
+            this.reason = reason;
+        }
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/zerobase/zbcharger/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,67 @@
+package com.zerobase.zbcharger.exception.handler;
+
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.ARGUMENT_NOT_VALID;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.UNHANDLED_ERROR;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import com.zerobase.zbcharger.exception.CustomException;
+import com.zerobase.zbcharger.exception.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    private ResponseEntity<ErrorResponse> handleBusinessException(
+        HttpServletRequest request,
+        CustomException e) {
+        log.error("{} is occurred.", e.getErrorCode(), e);
+        return new ResponseEntity<>(
+            ErrorResponse.of(request.getRequestURI(), e.getErrorCode()),
+            e.getErrorCode().getStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    private ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+        HttpServletRequest request,
+        MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException is occurred.", e);
+        return new ResponseEntity<>(
+            ErrorResponse.of(
+                request.getRequestURI(),
+                ARGUMENT_NOT_VALID,
+                e.getFieldErrors()),
+            BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    private ResponseEntity<ErrorResponse> handleHandlerMethodValidationException(
+        HttpServletRequest request,
+        HandlerMethodValidationException e) {
+        log.error("HandlerMethodValidationException is occurred.", e);
+        return new ResponseEntity<>(
+            ErrorResponse.of(
+                request.getRequestURI(),
+                ARGUMENT_NOT_VALID,
+                null),
+            BAD_REQUEST);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    private ResponseEntity<ErrorResponse> handleRuntimeException(
+        HttpServletRequest request,
+        RuntimeException e) {
+        log.error("RuntimeException is occurred.", e);
+        return new ResponseEntity<>(
+            ErrorResponse.of(request.getRequestURI(), UNHANDLED_ERROR),
+            INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/test/java/com/zerobase/zbcharger/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/zerobase/zbcharger/domain/member/controller/MemberControllerTest.java
@@ -1,6 +1,8 @@
 package com.zerobase.zbcharger.domain.member.controller;
 
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.ARGUMENT_NOT_VALID;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.zerobase.zbcharger.domain.member.dto.RegisterMemberRequest;
@@ -73,7 +75,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("email"));
     }
 
     @Test
@@ -92,7 +97,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("email"));
     }
 
     @Test
@@ -111,7 +119,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("password"));
     }
 
     @Test
@@ -130,7 +141,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("password"));
     }
 
     @Test
@@ -149,7 +163,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("password"));
     }
 
     @Test
@@ -168,7 +185,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("password"));
     }
 
     @Test
@@ -187,7 +207,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("password"));
     }
 
     @Test
@@ -206,7 +229,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("password"));
     }
 
     @Test
@@ -225,7 +251,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("name"));
     }
 
     @Test
@@ -244,7 +273,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("name"));
     }
 
     @Test
@@ -263,7 +295,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("name"));
     }
 
     @Test
@@ -282,7 +317,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("name"));
     }
 
     @Test
@@ -301,7 +339,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("phone"));
     }
 
     @Test
@@ -320,7 +361,10 @@ class MemberControllerTest {
             request);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()))
+            .andExpect(jsonPath("$.errors[0].field").value("phone"));
     }
 
     @Test
@@ -354,7 +398,9 @@ class MemberControllerTest {
         ResultActions resultActions = MockMvcUtils.performGet(mockMvc, url);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()));
     }
 
     @Test
@@ -370,6 +416,8 @@ class MemberControllerTest {
         ResultActions resultActions = MockMvcUtils.performGet(mockMvc, url);
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(ARGUMENT_NOT_VALID.toString()));
     }
 }

--- a/src/test/java/com/zerobase/zbcharger/domain/member/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/zerobase/zbcharger/domain/member/service/EmailVerificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.zerobase.zbcharger.domain.member.service;
 
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.EMAIL_VERIFICATION_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 import com.zerobase.zbcharger.domain.member.dao.EmailVerificationRepository;
 import com.zerobase.zbcharger.domain.member.entity.EmailVerification;
 import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.exception.CustomException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,10 +49,10 @@ class EmailVerificationServiceTest {
             .willReturn(Optional.empty());
 
         // when
-        RuntimeException exception = assertThrows(RuntimeException.class,
+        CustomException exception = assertThrows(CustomException.class,
             () -> emailVerificationService.verifyEmail(any(), any()));
 
         // then
-        assertEquals("not found", exception.getMessage());
+        assertEquals(EMAIL_VERIFICATION_NOT_FOUND, exception.getErrorCode());
     }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
일관된 예외 메시지를 응답하게 위해, 예외 코드를 정의하고 전역 예외 핸들러에서 응답 메시지를 반환하도록 처리했습니다.

**AS-IS**

**TO-BE**
- ErrorCode
  - 에러코드 열거 형태로 정의
- CustomException
  - 공통 예외를 발생시키기 위한 예외 클래스
- ErrorResponse
  - 에러 발생 시 클라이언트에 응답하는 에러 응답 DTO
- GlobalExceptionHandler
  - Controller를 포함한 내부 레이어에서 발생하는 모든 예외를 처리하기 위한 핸들러  

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
