### PR TITLE
feat: issue membership card

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,45 +1,46 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.0'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.0'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.zerobase'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-mail'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'org.mariadb.jdbc:mariadb-java-client:3.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.mariadb.jdbc:mariadb-java-client:3.2.0'
+    implementation 'org.redisson:redisson:3.25.2'
 //	implementation 'org.mariadb.jdbc:mariadb-java-client:2.7.11' # profileSql 확인용
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	implementation 'io.jsonwebtoken:jjwt:0.12.3'
-	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+    implementation 'io.jsonwebtoken:jjwt:0.12.3'
+    implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 

--- a/src/http/auth.http
+++ b/src/http/auth.http
@@ -1,0 +1,12 @@
+POST {{host}}/auth/token
+content-type: application/json
+accept: application/json
+
+{
+    "email":"e-tap@naver.com",
+    "password":"1q2w#E$R"
+}
+
+> {%
+  client.global.set("accessToken", response.body.accessToken);
+%}

--- a/src/http/http-client.env.json
+++ b/src/http/http-client.env.json
@@ -1,0 +1,5 @@
+{
+  "dev": {
+    "host": "http://localhost:8080"
+  }
+}

--- a/src/http/membership.http
+++ b/src/http/membership.http
@@ -1,0 +1,30 @@
+### 카드 발급
+POST {{host}}/memberships/issue
+Authorization: Bearer {{accessToken}}
+content-type: application/json
+accept: application/json
+
+{
+  "cardType": "PHYSICAL"
+}
+
+> {%
+  client.global.set("cardNo", response.body.cardNo);
+%}
+
+
+### 카드 등록
+POST {{host}}/memberships/register
+Authorization: Bearer {{accessToken}}
+content-type: application/json
+accept: application/json
+
+{
+  "cardNo": "{{cardNo}}"
+}
+
+
+### 카드 조회
+GET {{host}}/memberships
+Authorization: Bearer {{accessToken}}
+accept: application/json

--- a/src/main/java/com/zerobase/zbcharger/aop/lock/DistributedLock.java
+++ b/src/main/java/com/zerobase/zbcharger/aop/lock/DistributedLock.java
@@ -1,0 +1,36 @@
+package com.zerobase.zbcharger.aop.lock;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 분산 락을 사용하기 위한 어노테이션
+ */
+@Target(ElementType.METHOD)
+@Retention(RUNTIME)
+public @interface DistributedLock {
+
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s) 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 3s) 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/com/zerobase/zbcharger/aop/lock/DistributedLockAop.java
+++ b/src/main/java/com/zerobase/zbcharger/aop/lock/DistributedLockAop.java
@@ -1,0 +1,73 @@
+package com.zerobase.zbcharger.aop.lock;
+
+import com.zerobase.zbcharger.util.CustomSpELParser;
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+/**
+ * 분산 락을 사용하기 위한 AOP<br/> Redisson 을 사용하여 분산 락을 사용한다
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(com.zerobase.zbcharger.aop.lock.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+        String key = getLockKey(signature.getParameterNames(), joinPoint.getArgs(),
+            distributedLock.key());
+
+        Object kvKey = kv("key", key);
+
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(),
+                distributedLock.leaseTime(), distributedLock.timeUnit());
+
+            if (!available) {
+                log.trace("redisson lock tryLock fail {}", kvKey);
+                return false;
+            }
+
+            log.trace("redisson lock tryLock success {}", kvKey);
+            return joinPoint.proceed();
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            try {
+                rLock.unlock();
+                log.trace("redisson lock unlock success {}", kvKey);
+            } catch (IllegalMonitorStateException e) {
+                log.error("redisson lock already unlock {} {}",
+                    kv("method", method.getName()),
+                    kv("key", key)
+                );
+            }
+        }
+    }
+
+    private static String getLockKey(String[] parameterNames, Object[] args, String key) {
+        return REDISSON_LOCK_PREFIX + CustomSpELParser.getDynamicValue(parameterNames, args, key);
+    }
+
+    private static Object kv(String method, String name) {
+        return String.format("%s=%s", method, name);
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/configuration/redis/RedisConfiguration.java
+++ b/src/main/java/com/zerobase/zbcharger/configuration/redis/RedisConfiguration.java
@@ -1,0 +1,25 @@
+package com.zerobase.zbcharger.configuration.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfiguration {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://" + host + ":" + port);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/configuration/security/annotation/CurrentUser.java
+++ b/src/main/java/com/zerobase/zbcharger/configuration/security/annotation/CurrentUser.java
@@ -1,0 +1,15 @@
+package com.zerobase.zbcharger.configuration.security.annotation;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target({PARAMETER})
+@Retention(RUNTIME)
+@AuthenticationPrincipal(expression = "member")
+public @interface CurrentUser {
+
+}

--- a/src/main/java/com/zerobase/zbcharger/configuration/security/annotation/RoleUser.java
+++ b/src/main/java/com/zerobase/zbcharger/configuration/security/annotation/RoleUser.java
@@ -1,0 +1,16 @@
+package com.zerobase.zbcharger.configuration.security.annotation;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Target({METHOD, TYPE})
+@Retention(RUNTIME)
+@PreAuthorize("hasRole('USER')")
+public @interface RoleUser {
+
+}

--- a/src/main/java/com/zerobase/zbcharger/configuration/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/zbcharger/configuration/security/filter/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.zerobase.zbcharger.configuration.security.filter;
 import static com.zerobase.zbcharger.configuration.security.RequestMatchers.JWT_FILTER_REQUEST_MATCHER;
 import static com.zerobase.zbcharger.exception.constant.ErrorCode.TOKEN_EXPIRED;
 import static com.zerobase.zbcharger.exception.constant.ErrorCode.TOKEN_INVALID;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.TOKEN_REQUIRED;
 
 import com.zerobase.zbcharger.configuration.security.jwt.JwtAuthenticationException;
 import com.zerobase.zbcharger.configuration.security.jwt.JwtAuthenticationToken;
@@ -16,16 +17,15 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
-import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 
 /**
  * JWT 인증 필터
  */
-@Component
 public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
     private static final String TOKEN_HEADER = "Authorization";
@@ -46,7 +46,7 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
 
         String accessToken = obtainAccessToken(request);
         if (ObjectUtils.isEmpty(accessToken)) {
-            return null;
+            throw new JwtAuthenticationException(TOKEN_REQUIRED);
         }
         Claims claims = obtainClaims(accessToken);
 
@@ -55,7 +55,6 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
             accessToken);
 
         return this.getAuthenticationManager().authenticate(authRequest);
-
     }
 
     @Nullable

--- a/src/main/java/com/zerobase/zbcharger/configuration/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/zerobase/zbcharger/configuration/security/jwt/JwtAuthenticationProvider.java
@@ -1,6 +1,7 @@
 package com.zerobase.zbcharger.configuration.security.jwt;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -23,7 +24,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         UserDetails userDetails = userDetailsService.loadUserByUsername(
             authentication.getPrincipal().toString());
 
-        return JwtAuthenticationToken.authenticated(userDetails.getUsername(),
+        return JwtAuthenticationToken.authenticated(userDetails,
             authentication.getCredentials(), userDetails.getAuthorities());
     }
 

--- a/src/main/java/com/zerobase/zbcharger/configuration/security/jwt/JwtUserDetails.java
+++ b/src/main/java/com/zerobase/zbcharger/configuration/security/jwt/JwtUserDetails.java
@@ -4,10 +4,12 @@ import com.zerobase.zbcharger.domain.member.entity.Member;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+@Getter
 public class JwtUserDetails implements UserDetails {
 
     private final static String ROLE_PREFIX = "ROLE_";

--- a/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Charger.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Charger.java
@@ -1,6 +1,7 @@
 package com.zerobase.zbcharger.domain.charger.entity;
 
 import com.zerobase.zbcharger.domain.common.entity.AuditableEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Transient;
@@ -38,6 +39,7 @@ public class Charger extends AuditableEntity implements Persistable<String> {
     /**
      * 충전기 타입
      */
+    @Column(columnDefinition = "char(2)")
     private final String chargerType;
 
     /**

--- a/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Company.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Company.java
@@ -1,6 +1,7 @@
 package com.zerobase.zbcharger.domain.charger.entity;
 
 import com.zerobase.zbcharger.domain.common.entity.AuditableEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Transient;
@@ -27,6 +28,7 @@ public class Company extends AuditableEntity implements Persistable<String> {
      * 아이디
      */
     @Id
+    @Column(columnDefinition = "char(2)")
     private final String id;
 
     /**

--- a/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Station.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Station.java
@@ -33,6 +33,7 @@ public class Station extends AuditableEntity implements Persistable<String> {
     /**
      * 회사 아이디
      */
+    @Column(columnDefinition = "char(2)")
     private final String companyId;
 
     /**
@@ -53,21 +54,25 @@ public class Station extends AuditableEntity implements Persistable<String> {
     /**
      * 지역 코드
      */
+    @Column(columnDefinition = "char(2)")
     private final String areaCode;
 
     /**
      * 지역구분 상세 코드
      */
+    @Column(columnDefinition = "char(5)")
     private final String areaDetailCode;
 
     /**
      * 충전소 구분 코드
      */
+    @Column(columnDefinition = "char(2)")
     private final String stationKindCode;
 
     /**
      * 충전소 구분 상세 코드
      */
+    @Column(columnDefinition = "char(4)")
     private final String stationKindDetailCode;
 
     /**
@@ -88,7 +93,7 @@ public class Station extends AuditableEntity implements Persistable<String> {
     /**
      * 이용제한 사유
      */
-    private final boolean useLimitDetail;
+    private final String useLimitDetail;
 
     /**
      * 편의제공 여부

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/controller/MembershipController.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/controller/MembershipController.java
@@ -1,0 +1,69 @@
+package com.zerobase.zbcharger.domain.membership.controller;
+
+import com.zerobase.zbcharger.configuration.security.annotation.CurrentUser;
+import com.zerobase.zbcharger.configuration.security.annotation.RoleUser;
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.domain.membership.dto.IssueMembershipCardRequest;
+import com.zerobase.zbcharger.domain.membership.dto.IssueMembershipCardResponse;
+import com.zerobase.zbcharger.domain.membership.dto.MembershipCardDto;
+import com.zerobase.zbcharger.domain.membership.dto.RegisterMembershipCardRequest;
+import com.zerobase.zbcharger.domain.membership.entity.MembershipCard;
+import com.zerobase.zbcharger.domain.membership.service.IssueMembershipService;
+import com.zerobase.zbcharger.domain.membership.service.MembershipService;
+import com.zerobase.zbcharger.domain.membership.service.RegisterMembershipService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 멤버십 컨트롤러
+ */
+@RoleUser
+@RestController
+@RequiredArgsConstructor
+public class MembershipController {
+
+    private final IssueMembershipService issueMembershipService;
+    private final RegisterMembershipService registerMembershipService;
+    private final MembershipService membershipService;
+
+    /**
+     * 멤버십 카드 발급 신청
+     */
+    @PostMapping("/memberships/issue")
+    public ResponseEntity<IssueMembershipCardResponse> issueCard(
+        @Valid @RequestBody IssueMembershipCardRequest request,
+        @CurrentUser Member member) {
+        MembershipCard membershipCard = issueMembershipService.issueCard(member, request);
+        return ResponseEntity.ok(IssueMembershipCardResponse.from(membershipCard));
+    }
+
+    /**
+     * 멤버십 카드 등록
+     */
+    @PostMapping("/memberships/register")
+    public ResponseEntity<Void> registerCard(
+        @Valid @RequestBody RegisterMembershipCardRequest request,
+        @CurrentUser Member member) {
+        registerMembershipService.registerCard(member, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 멤버십 카드 조회
+     */
+    @GetMapping("/memberships")
+    public ResponseEntity<List<MembershipCardDto>> getCards(@CurrentUser Member member) {
+        return ResponseEntity.ok(
+            membershipService.getCards(member)
+                .stream()
+                .map(MembershipCardDto::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/dao/MembershipCardRepository.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/dao/MembershipCardRepository.java
@@ -1,0 +1,18 @@
+package com.zerobase.zbcharger.domain.membership.dao;
+
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.domain.membership.entity.CardType;
+import com.zerobase.zbcharger.domain.membership.entity.MembershipCard;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MembershipCardRepository extends JpaRepository<MembershipCard, String> {
+
+    List<MembershipCard> findAllByMemberId(Long memberId);
+
+    boolean existsByMemberAndCardType(Member member, CardType cardType);
+
+    long countByCardType(CardType cardType);
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/dto/IssueMembershipCardRequest.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/dto/IssueMembershipCardRequest.java
@@ -1,0 +1,18 @@
+package com.zerobase.zbcharger.domain.membership.dto;
+
+import static com.zerobase.zbcharger.validator.constant.ValidationMessage.INVALID_CARD_TYPE;
+
+import com.zerobase.zbcharger.domain.membership.entity.CardType;
+import com.zerobase.zbcharger.validator.annotation.EnumValue;
+import jakarta.persistence.Convert;
+
+/**
+ * 멤버십 카드 발급 요청
+ *
+ * @param cardType 카드 타입
+ */
+public record IssueMembershipCardRequest(
+    @EnumValue(enumClass = CardType.class, message = INVALID_CARD_TYPE) String cardType
+) {
+
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/dto/IssueMembershipCardResponse.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/dto/IssueMembershipCardResponse.java
@@ -1,0 +1,23 @@
+package com.zerobase.zbcharger.domain.membership.dto;
+
+import com.zerobase.zbcharger.domain.membership.entity.CardType;
+import com.zerobase.zbcharger.domain.membership.entity.MembershipCard;
+
+/**
+ * 멤버십 카드 발급 응답
+ *
+ * @param cardNo   카드 번호
+ * @param cardType 카드 타입
+ */
+public record IssueMembershipCardResponse(
+    String cardNo,
+    CardType cardType
+) {
+
+    public static IssueMembershipCardResponse from(MembershipCard membershipCard) {
+        return new IssueMembershipCardResponse(
+            membershipCard.getCardNo(),
+            membershipCard.getCardType()
+        );
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/dto/MembershipCardDto.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/dto/MembershipCardDto.java
@@ -1,0 +1,17 @@
+package com.zerobase.zbcharger.domain.membership.dto;
+
+import com.zerobase.zbcharger.domain.membership.entity.CardType;
+import com.zerobase.zbcharger.domain.membership.entity.MembershipCard;
+
+public record MembershipCardDto(
+    String cardNo,
+    CardType cardType
+) {
+
+    public static MembershipCardDto from(MembershipCard membershipCard) {
+        return new MembershipCardDto(
+            membershipCard.getCardNo(),
+            membershipCard.getCardType()
+        );
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/dto/RegisterMembershipCardRequest.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/dto/RegisterMembershipCardRequest.java
@@ -1,0 +1,14 @@
+package com.zerobase.zbcharger.domain.membership.dto;
+
+import com.zerobase.zbcharger.validator.annotation.MembershipCard;
+
+/**
+ * 멤버십 카드 등록 요청
+ *
+ * @param cardNo 카드 번호
+ */
+public record RegisterMembershipCardRequest(
+    @MembershipCard String cardNo
+) {
+
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/entity/CardType.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/entity/CardType.java
@@ -1,0 +1,24 @@
+package com.zerobase.zbcharger.domain.membership.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 멤버십 카드 종류
+ */
+@Getter
+@RequiredArgsConstructor
+public enum CardType {
+
+    /**
+     * 실물 카드
+     */
+    PHYSICAL(1),
+
+    /**
+     * 모바일 카드
+     */
+    MOBILE(2);
+
+    private final int value;
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/entity/MembershipCard.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/entity/MembershipCard.java
@@ -1,0 +1,67 @@
+package com.zerobase.zbcharger.domain.membership.entity;
+
+import com.zerobase.zbcharger.domain.common.entity.AuditableEntity;
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 멤버십 카드
+ */
+@Entity
+@Getter
+@NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)
+public class MembershipCard extends AuditableEntity {
+
+    /**
+     * 카드 번호
+     */
+    @Id
+    @Column(columnDefinition = "char(19)")
+    private final String cardNo;
+
+    /**
+     * 회원
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    private final Member member;
+
+    /**
+     * 카드 종류
+     */
+    @Enumerated(EnumType.STRING)
+    private final CardType cardType;
+
+    /**
+     * 카드 사용등록 일시
+     */
+    private LocalDateTime registeredAt;
+
+    @Builder
+    private MembershipCard(String cardNo, Member member, CardType cardType) {
+        this.cardNo = cardNo;
+        this.member = member;
+        this.cardType = cardType;
+
+        if (cardType == CardType.MOBILE) {
+            this.registeredAt = LocalDateTime.now();
+        }
+    }
+
+    /**
+     * 카드 등록
+     */
+    public void register() {
+        this.registeredAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/service/IssueMembershipService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/service/IssueMembershipService.java
@@ -1,0 +1,81 @@
+package com.zerobase.zbcharger.domain.membership.service;
+
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.MEMBERSHIP_CARD_ALREADY_ISSUED;
+
+import com.zerobase.zbcharger.aop.lock.DistributedLock;
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.domain.membership.dao.MembershipCardRepository;
+import com.zerobase.zbcharger.domain.membership.dto.IssueMembershipCardRequest;
+import com.zerobase.zbcharger.domain.membership.entity.CardType;
+import com.zerobase.zbcharger.domain.membership.entity.MembershipCard;
+import com.zerobase.zbcharger.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 멤버십 카드 발급 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class IssueMembershipService {
+
+    private static final int CARD_NO_LENGTH = 16;
+
+    private final MembershipCardRepository membershipCardRepository;
+
+    /**
+     * 멤버십 카드 발급
+     *
+     * @param member  회원
+     * @param request 멤버십 카드 발급 요청
+     * @return 멤버십 카드
+     */
+    @Transactional
+    @DistributedLock(key = "'issueMembershipCard'")
+    public MembershipCard issueCard(Member member, IssueMembershipCardRequest request) {
+        CardType cardType = CardType.valueOf(request.cardType());
+
+        checkMembershipCardAlreadyIssued(member, cardType);
+
+        MembershipCard membershipCard = MembershipCard.builder()
+            .member(member)
+            .cardType(cardType)
+            .cardNo(generateMembershipCardNo(cardType))
+            .build();
+
+        return membershipCardRepository.save(membershipCard);
+    }
+
+    /**
+     * 같은 타입의 멤버십 카드를 발급했는지 확인
+     *
+     * @param member   회원
+     * @param cardType 카드 타입
+     */
+    private void checkMembershipCardAlreadyIssued(Member member, CardType cardType) {
+        if (membershipCardRepository.existsByMemberAndCardType(member, cardType)) {
+            throw new CustomException(MEMBERSHIP_CARD_ALREADY_ISSUED);
+        }
+    }
+
+    /**
+     * 순차적으로 카드 번호 생성
+     *
+     * @param cardType 카드 타입
+     * @return 카드 번호
+     */
+    private String generateMembershipCardNo(CardType cardType) {
+        long nextCardNo = membershipCardRepository.countByCardType(cardType) + 1;
+        String tmp = String.format("%0" + (CARD_NO_LENGTH - 1) + "d", nextCardNo);
+        StringBuilder cardNo = new StringBuilder();
+        cardNo.append(cardType.getValue());
+        for (int i = 0; i < tmp.length(); i++) {
+            if (cardNo.length() % 5 == 4) {
+                cardNo.append("-");
+            }
+            cardNo.append(tmp.charAt(i));
+        }
+        return cardNo.toString();
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/service/MembershipService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/service/MembershipService.java
@@ -1,0 +1,21 @@
+package com.zerobase.zbcharger.domain.membership.service;
+
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.domain.membership.dao.MembershipCardRepository;
+import com.zerobase.zbcharger.domain.membership.entity.MembershipCard;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MembershipService {
+
+    private final MembershipCardRepository membershipCardRepository;
+
+    @Transactional(readOnly = true)
+    public List<MembershipCard> getCards(Member member) {
+        return membershipCardRepository.findAllByMemberId(member.getId());
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/membership/service/RegisterMembershipService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/membership/service/RegisterMembershipService.java
@@ -1,0 +1,78 @@
+package com.zerobase.zbcharger.domain.membership.service;
+
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.ACCESS_DENIED;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.MEMBERSHIP_CARD_ALREADY_REGISTERED;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.MEMBERSHIP_CARD_NOT_FOUND;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.ONLY_PHYSICAL_CARD_COULD_REGISTER;
+
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.domain.membership.dao.MembershipCardRepository;
+import com.zerobase.zbcharger.domain.membership.dto.RegisterMembershipCardRequest;
+import com.zerobase.zbcharger.domain.membership.entity.CardType;
+import com.zerobase.zbcharger.domain.membership.entity.MembershipCard;
+import com.zerobase.zbcharger.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 멤버십 카드 등록 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class RegisterMembershipService {
+
+    private final MembershipCardRepository membershipCardRepository;
+
+    /**
+     * 멤버십 카드 등록
+     *
+     * @param member  회원
+     * @param request 멤버십 카드 등록 요청
+     */
+    @Transactional
+    public void registerCard(Member member, RegisterMembershipCardRequest request) {
+        MembershipCard membershipCard = membershipCardRepository.findById(request.cardNo())
+            .orElseThrow(() -> new CustomException(MEMBERSHIP_CARD_NOT_FOUND));
+
+        checkCardTypeIsPhysical(membershipCard);
+        checkCardAlreadyRegistered(membershipCard);
+        checkAuthority(membershipCard, member);
+
+        membershipCard.register();
+    }
+
+    /**
+     * 카드 타입이 물리카드인지 확인
+     *
+     * @param membershipCard 멤버십 카드
+     */
+    private void checkCardTypeIsPhysical(MembershipCard membershipCard) {
+        if (membershipCard.getCardType() != CardType.PHYSICAL) {
+            throw new CustomException(ONLY_PHYSICAL_CARD_COULD_REGISTER);
+        }
+    }
+
+    /**
+     * 카드가 이미 등록되었는지 확인
+     *
+     * @param membershipCard 멤버십 카드
+     */
+    private void checkCardAlreadyRegistered(MembershipCard membershipCard) {
+        if (membershipCard.getRegisteredAt() != null) {
+            throw new CustomException(MEMBERSHIP_CARD_ALREADY_REGISTERED);
+        }
+    }
+
+    /**
+     * 권한 확인
+     *
+     * @param membershipCard 멤버십 카드
+     * @param member         회원
+     */
+    private void checkAuthority(MembershipCard membershipCard, Member member) {
+        if (!membershipCard.getMember().getId().equals(member.getId())) {
+            throw new CustomException(ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/exception/constant/ErrorCode.java
+++ b/src/main/java/com/zerobase/zbcharger/exception/constant/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     AUTHENTICATION_INVALID(UNAUTHORIZED, "아이디를 찾을 수 없거나, 비밀번호가 일치하지 않습니다."),
     TOKEN_INVALID(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(UNAUTHORIZED, "토큰이 만료됐습니다."),
+    TOKEN_REQUIRED(UNAUTHORIZED, "토큰이 필요합니다."),
 
     EMAIL_ALREADY_EXISTS(CONFLICT, "중복되는 메일이 존재합니다."),
 

--- a/src/main/java/com/zerobase/zbcharger/exception/constant/ErrorCode.java
+++ b/src/main/java/com/zerobase/zbcharger/exception/constant/ErrorCode.java
@@ -2,6 +2,7 @@ package com.zerobase.zbcharger.exception.constant;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
@@ -22,6 +23,12 @@ public enum ErrorCode {
     TOKEN_INVALID(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(UNAUTHORIZED, "토큰이 만료됐습니다."),
     TOKEN_REQUIRED(UNAUTHORIZED, "토큰이 필요합니다."),
+
+    MEMBERSHIP_CARD_ALREADY_ISSUED(BAD_REQUEST, "멤버십 카드를 이미 발급받았습니다."),
+    MEMBERSHIP_CARD_ALREADY_REGISTERED(BAD_REQUEST, "이미 등록된 멤버십 카드입니다."),
+    MEMBERSHIP_CARD_NOT_FOUND(NOT_FOUND, "멤버십 카드를 찾을 수 없습니다."),
+    ONLY_PHYSICAL_CARD_COULD_REGISTER(BAD_REQUEST, "물리 카드만 등록할 수 있습니다."),
+    ACCESS_DENIED(FORBIDDEN, "접근 권한이 없습니다."),
 
     EMAIL_ALREADY_EXISTS(CONFLICT, "중복되는 메일이 존재합니다."),
 

--- a/src/main/java/com/zerobase/zbcharger/util/CustomSpELParser.java
+++ b/src/main/java/com/zerobase/zbcharger/util/CustomSpELParser.java
@@ -1,0 +1,20 @@
+package com.zerobase.zbcharger.util;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public final class CustomSpELParser {
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args,
+        String expressionString) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(expressionString).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/validator/EnumValueValidator.java
+++ b/src/main/java/com/zerobase/zbcharger/validator/EnumValueValidator.java
@@ -1,0 +1,37 @@
+package com.zerobase.zbcharger.validator;
+
+import com.zerobase.zbcharger.validator.annotation.EnumValue;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValueValidator implements ConstraintValidator<EnumValue, String> {
+
+    private EnumValue enumValue;
+
+    @Override
+    public void initialize(EnumValue constraintAnnotation) {
+        this.enumValue = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
+
+        Enum<?>[] enumValues = this.enumValue.enumClass().getEnumConstants();
+
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value.equals(enumValue.toString())
+                    || this.enumValue.ignoreCase() && value.equalsIgnoreCase(
+                    enumValue.toString())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}
+

--- a/src/main/java/com/zerobase/zbcharger/validator/MembershipCardValidator.java
+++ b/src/main/java/com/zerobase/zbcharger/validator/MembershipCardValidator.java
@@ -1,0 +1,18 @@
+package com.zerobase.zbcharger.validator;
+
+import com.zerobase.zbcharger.validator.annotation.MembershipCard;
+import com.zerobase.zbcharger.validator.constant.RegexPattern;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class MembershipCardValidator implements ConstraintValidator<MembershipCard, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
+
+        return value.matches(RegexPattern.MEMBERSHIP_CARD);
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/validator/annotation/EnumValue.java
+++ b/src/main/java/com/zerobase/zbcharger/validator/annotation/EnumValue.java
@@ -1,0 +1,24 @@
+package com.zerobase.zbcharger.validator.annotation;
+
+import com.zerobase.zbcharger.validator.EnumValueValidator;
+import jakarta.validation.Constraint;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EnumValueValidator.class)
+public @interface EnumValue {
+
+    Class<? extends Enum<?>> enumClass();
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class[] payload() default {};
+
+    boolean ignoreCase() default true;
+}

--- a/src/main/java/com/zerobase/zbcharger/validator/annotation/MembershipCard.java
+++ b/src/main/java/com/zerobase/zbcharger/validator/annotation/MembershipCard.java
@@ -1,0 +1,21 @@
+package com.zerobase.zbcharger.validator.annotation;
+
+import com.zerobase.zbcharger.validator.MembershipCardValidator;
+import com.zerobase.zbcharger.validator.constant.ValidationMessage;
+import jakarta.validation.Constraint;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MembershipCardValidator.class)
+public @interface MembershipCard {
+
+    String message() default ValidationMessage.INVALID_MEMBERSHIP_CARD_FORMAT;
+
+    Class[] groups() default {};
+
+    Class[] payload() default {};
+}

--- a/src/main/java/com/zerobase/zbcharger/validator/constant/RegexPattern.java
+++ b/src/main/java/com/zerobase/zbcharger/validator/constant/RegexPattern.java
@@ -10,4 +10,6 @@ public final class RegexPattern {
      * 소문자, 대문자, 숫자, 특수문자 각각 최소 1개 이상을 포함하는 8자리 이상 20자리 이하
      */
     public static final String PASSWORD = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()-_=+]).{8,20}$";
+
+    public static final String MEMBERSHIP_CARD = "\\d{4}-\\d{4}-\\d{4}-\\d{4}";
 }

--- a/src/main/java/com/zerobase/zbcharger/validator/constant/ValidationMessage.java
+++ b/src/main/java/com/zerobase/zbcharger/validator/constant/ValidationMessage.java
@@ -6,4 +6,6 @@ public final class ValidationMessage {
     public static final String INVALID_EMAIL_FORMAT = "유효하지 않은 이메일 형식입니다.";
     public static final String INVALID_MEMBER_NAME_FORMAT = "유효하지 않은 이름 형식입니다.";
     public static final String INVALID_PASSWORD_FORMAT = "패스워드는 소문자, 대문자, 숫자, 특수문자 각각 최소 1개 이상을 포함하는 8자리 이상 20자리 이하의 문자열입니다.";
+    public static final String INVALID_MEMBERSHIP_CARD_FORMAT = "유효하지 않은 카드번호 형식입니다.";
+    public static final String INVALID_CARD_TYPE = "유효하지 않은 카드 타입입니다.";
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,5 +29,8 @@ spring:
   #        generate_statistics: true
   jwt:
     secretKey: emItc3ByaW5nLWJvb3QtemJjaGFyZ2VyLXByb2plY3Qtand0LXNlY3JldC1rZXk=
+  data.redis:
+    host: localhost
+    port: 6379
 
 api.uri: http://localhost:8080

--- a/src/test/java/com/zerobase/zbcharger/domain/membership/controller/MembershipControllerTest.java
+++ b/src/test/java/com/zerobase/zbcharger/domain/membership/controller/MembershipControllerTest.java
@@ -1,0 +1,127 @@
+package com.zerobase.zbcharger.domain.membership.controller;
+
+import static com.zerobase.zbcharger.domain.membership.entity.CardType.PHYSICAL;
+import static com.zerobase.zbcharger.validator.constant.ValidationMessage.INVALID_CARD_TYPE;
+import static com.zerobase.zbcharger.validator.constant.ValidationMessage.INVALID_MEMBERSHIP_CARD_FORMAT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.zerobase.zbcharger.configuration.security.WebSecurityConfiguration;
+import com.zerobase.zbcharger.configuration.security.filter.JwtAuthenticationFilter;
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.domain.membership.dto.IssueMembershipCardRequest;
+import com.zerobase.zbcharger.domain.membership.dto.RegisterMembershipCardRequest;
+import com.zerobase.zbcharger.domain.membership.entity.MembershipCard;
+import com.zerobase.zbcharger.domain.membership.service.IssueMembershipService;
+import com.zerobase.zbcharger.domain.membership.service.MembershipService;
+import com.zerobase.zbcharger.domain.membership.service.RegisterMembershipService;
+import com.zerobase.zbcharger.util.MockMvcUtils;
+import com.zerobase.zbcharger.util.ResultActionsUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(value = MembershipController.class,
+    excludeAutoConfiguration = {SecurityAutoConfiguration.class},
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+            WebSecurityConfiguration.class,
+            JwtAuthenticationFilter.class
+        })
+    })
+class MembershipControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RegisterMembershipService registerMembershipService;
+
+    @MockBean
+    private IssueMembershipService issueMembershipService;
+
+    @MockBean
+    private MembershipService membershipService;
+
+    private static final String MOCK_CARD_NUMBER = "1000-0000-0000-0001";
+    private static final Member MOCK_MEMBER = Member.builder().build();
+    private static final MembershipCard MOCK_MEMBERSHIP_CARD = MembershipCard.builder()
+        .cardNo(MOCK_CARD_NUMBER)
+        .member(MOCK_MEMBER)
+        .cardType(PHYSICAL)
+        .build();
+
+    @Test
+    @DisplayName("멤버십 카드 발급 성공")
+    void successIssueMembershipCard() throws Exception {
+        // given
+        IssueMembershipCardRequest request = new IssueMembershipCardRequest(PHYSICAL.name());
+
+        given(issueMembershipService.issueCard(any(Member.class), eq(request)))
+            .willReturn(MOCK_MEMBERSHIP_CARD);
+
+        // when
+        ResultActions resultActions = MockMvcUtils.performPost(mockMvc, "/memberships/issue",
+            request);
+
+        // then
+        resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.cardNo").value(MOCK_CARD_NUMBER))
+            .andExpect(jsonPath("$.cardType").value(PHYSICAL.name()));
+    }
+
+    @Test
+    @DisplayName("멤버십 카드 발급 실패 - 카드 타입 유효성")
+    void failIssueMembershipCard_cardType_invalid() throws Exception {
+        // given
+        IssueMembershipCardRequest request = new IssueMembershipCardRequest("invalid-card-type");
+
+        // when
+        ResultActions resultActions = MockMvcUtils.performPost(mockMvc, "/memberships/issue",
+            request);
+
+        // then
+        ResultActionsUtils.expectArgumentNotValid(resultActions, "cardType", INVALID_CARD_TYPE);
+    }
+
+    @Test
+    @DisplayName("멤버십 카드 등록 성공")
+    void successRegisterMembershipCard() throws Exception {
+        // given
+        RegisterMembershipCardRequest request = new RegisterMembershipCardRequest(MOCK_CARD_NUMBER);
+
+        // when
+        ResultActions resultActions = MockMvcUtils.performPost(mockMvc, "/memberships/register",
+            request);
+
+        // then
+        resultActions.andExpect(status().isNoContent());
+        verify(registerMembershipService).registerCard(any(Member.class), eq(request));
+    }
+
+    @Test
+    @DisplayName("멤버십 카드 등록 실패 - 카드번호 유효성")
+    void failRegisterMembershipCard_invalid_cardNo() throws Exception {
+        // given
+        RegisterMembershipCardRequest request = new RegisterMembershipCardRequest("0000");
+
+        // when
+        ResultActions resultActions = MockMvcUtils.performPost(mockMvc, "/memberships/register",
+            request);
+
+        // then
+        ResultActionsUtils.expectArgumentNotValid(resultActions, "cardNo",
+            INVALID_MEMBERSHIP_CARD_FORMAT);
+    }
+}

--- a/src/test/java/com/zerobase/zbcharger/domain/membership/service/IssueMembershipServiceTest.java
+++ b/src/test/java/com/zerobase/zbcharger/domain/membership/service/IssueMembershipServiceTest.java
@@ -1,0 +1,55 @@
+package com.zerobase.zbcharger.domain.membership.service;
+
+import static com.zerobase.zbcharger.domain.membership.entity.CardType.PHYSICAL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.domain.membership.dao.MembershipCardRepository;
+import com.zerobase.zbcharger.domain.membership.dto.IssueMembershipCardRequest;
+import com.zerobase.zbcharger.domain.membership.entity.MembershipCard;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IssueMembershipServiceTest {
+
+    @Mock
+    private MembershipCardRepository membershipCardRepository;
+
+    @InjectMocks
+    private IssueMembershipService issueMembershipService;
+
+    private static final IssueMembershipCardRequest MOCK_REQUEST = new IssueMembershipCardRequest(
+        PHYSICAL.name());
+
+    private static final Member MOCK_MEMBER = mock(Member.class);
+
+    @BeforeAll
+    static void setup() {
+        given(MOCK_MEMBER.getId()).willReturn(1L);
+    }
+
+    @Test
+    @DisplayName("멤버십 카드 발급 성공")
+    void successIssueCard() {
+        // given
+        given(membershipCardRepository.existsByMemberAndCardType(any(Member.class), any()))
+            .willReturn(false);
+
+        // when
+        MembershipCard membershipCard = issueCard();
+
+        // then
+    }
+
+    MembershipCard issueCard() {
+        return issueMembershipService.issueCard(MOCK_MEMBER, MOCK_REQUEST);
+    }
+}

--- a/src/test/java/com/zerobase/zbcharger/domain/membership/service/RegisterMembershipServiceTest.java
+++ b/src/test/java/com/zerobase/zbcharger/domain/membership/service/RegisterMembershipServiceTest.java
@@ -1,0 +1,143 @@
+package com.zerobase.zbcharger.domain.membership.service;
+
+import static com.zerobase.zbcharger.domain.membership.entity.CardType.MOBILE;
+import static com.zerobase.zbcharger.domain.membership.entity.CardType.PHYSICAL;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.ACCESS_DENIED;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.MEMBERSHIP_CARD_ALREADY_REGISTERED;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.MEMBERSHIP_CARD_NOT_FOUND;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.ONLY_PHYSICAL_CARD_COULD_REGISTER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.domain.membership.dao.MembershipCardRepository;
+import com.zerobase.zbcharger.domain.membership.dto.RegisterMembershipCardRequest;
+import com.zerobase.zbcharger.domain.membership.entity.MembershipCard;
+import com.zerobase.zbcharger.exception.CustomException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterMembershipServiceTest {
+
+    @Mock
+    private MembershipCardRepository membershipCardRepository;
+
+    @InjectMocks
+    private RegisterMembershipService registerMembershipService;
+
+    private static final String MOCK_CARD_NUMBER = "1000-0000-0000-0001";
+
+    private static final Member MOCK_MEMBER = mock(Member.class);
+
+    private static final RegisterMembershipCardRequest MOCK_REQUEST = new RegisterMembershipCardRequest(
+        MOCK_CARD_NUMBER);
+
+    @BeforeAll
+    static void setup() {
+        given(MOCK_MEMBER.getId()).willReturn(1L);
+    }
+
+    @Test
+    @DisplayName("멤버십 카드 등록 성공")
+    void successRegisterCard() {
+        // given
+        MembershipCard membershipCard = mock(MembershipCard.class);
+        given(membershipCard.getCardType()).willReturn(PHYSICAL);
+        given(membershipCard.getMember()).willReturn(MOCK_MEMBER);
+
+        given(membershipCardRepository.findById(anyString()))
+            .willReturn(Optional.of(membershipCard));
+
+        // when
+        registerCard();
+
+        // then
+        verify(membershipCard).register();
+    }
+
+    @Test
+    @DisplayName("멤버십 카드 등록 실패 - 카드 없음")
+    void failRegisterCard_membership_card_not_found() {
+        // given
+        given(membershipCardRepository.findById(anyString()))
+            .willReturn(Optional.empty());
+
+        // when
+        CustomException customException = assertThrows(CustomException.class, this::registerCard);
+
+        // then
+        assertEquals(MEMBERSHIP_CARD_NOT_FOUND, customException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("멤버십 카드 등록 실패 - 물리 카드 아님")
+    void failRegisterCard_only_physical_card() {
+        // given
+        MembershipCard membershipCard = mock(MembershipCard.class);
+        given(membershipCard.getCardType()).willReturn(MOBILE);
+
+        given(membershipCardRepository.findById(anyString()))
+            .willReturn(Optional.of(membershipCard));
+
+        // when
+        CustomException customException = assertThrows(CustomException.class, this::registerCard);
+
+        // then
+        assertEquals(ONLY_PHYSICAL_CARD_COULD_REGISTER, customException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("멤버십 카드 등록 실패 - 이미 등록된 카드")
+    void failRegisterCard_already_registered() {
+        // given
+        MembershipCard membershipCard = mock(MembershipCard.class);
+        given(membershipCard.getCardType()).willReturn(PHYSICAL);
+        given(membershipCard.getRegisteredAt()).willReturn(LocalDateTime.now());
+
+        given(membershipCardRepository.findById(anyString()))
+            .willReturn(Optional.of(membershipCard));
+
+        // when
+        CustomException customException = assertThrows(CustomException.class, this::registerCard);
+
+        // then
+        assertEquals(MEMBERSHIP_CARD_ALREADY_REGISTERED, customException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("멤버십 카드 등록 실패 - 카드 소유주 아님")
+    void failRegisterCard_access_denied() {
+        // given
+        Member member = mock(Member.class);
+        given(member.getId()).willReturn(2L);
+
+        MembershipCard membershipCard = mock(MembershipCard.class);
+        given(membershipCard.getCardType()).willReturn(PHYSICAL);
+        given(membershipCard.getMember()).willReturn(member);
+
+        given(membershipCardRepository.findById(anyString()))
+            .willReturn(Optional.of(membershipCard));
+
+        // when
+        CustomException customException = assertThrows(CustomException.class, this::registerCard);
+
+        // then
+        assertEquals(ACCESS_DENIED, customException.getErrorCode());
+    }
+
+    void registerCard() {
+        registerMembershipService.registerCard(MOCK_MEMBER, MOCK_REQUEST);
+    }
+}


### PR DESCRIPTION
### 변경사항
충전 시 필요한 인증에 사용되는 멤버십 카드 발급 기능을 구현했습니다.

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
1. 카드 발급
  - 현재 발급된 카드 개수를 기반으로 +1씩하여 번호를 생성합니다.
  - 카드 번호 중복 발급을 방지하기 위해 redisson 분산락을 사용했습니다.
  - 카드는 회원 당 실물/모바일 카드 각 1개씩만 발급 가능합니다.
2. 카드 등록
  - 모바일 카드는 발급 시 바로 사용할 수 있습니다.(등록 api 호출 필요 없음)
3. 카드 조회
  - 회원 당 소지할 수 있는 카드는 최대 2개이기 때문에 페이징 구현 없이 List로 반환합니다.
4. controller에서 인증된 사용자 정보를 가져오기 위해 Member 엔티티를 반환하는 `@CurrentUser` 어노테이션을 만들었습니다.
  - 01.03 라이브에서 관련 내용에 대한 질문을 드렸고, 이 후 PR에서 수정할 예정입니다.

### 참고
https://helloworld.kurly.com/blog/distributed-redisson-lock/#2-redis의-redisson-라이브러리-선정-이유

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
