### PR TITLE
feat: register payment method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/gradle,java,intellij
 src/main/resources/application-datagokr.yml
 src/main/resources/application-email.yaml
+src/main/resources/application-payment.yml

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     implementation 'io.jsonwebtoken:jjwt:0.12.3'
     implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 
     implementation 'io.jsonwebtoken:jjwt:0.12.3'
     implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/http/payment.http
+++ b/src/http/payment.http
@@ -1,0 +1,28 @@
+### 스마트로 결제 수단 등록 (빌링 키 발급)
+POST {{host}}/payment/smartropay/issue-billing-callback
+Content-Type: application/x-www-form-urlencoded
+
+PayMethod = CARD &
+Mid = ZBCharger &
+BuyerName = 이태희 &
+Moid = 20190919123456789 &
+Tid = 20190919123456789 &
+BillTokenKey = OdoUbgo4EaqxLN9PtmPHIw== &
+MallUserId = 40 &
+ResultCode = 3001 &
+ResultMsg = 성공 &
+MallReserved = 20190919123456789 &
+VerifyValue = oRdbWkxpttFSESFuN4C329YWuvvLjBGwmW6XgUbo4ts= &
+IssuerCardCd = 11 &
+IssuerCardNm = 땡땡카드 &
+DisplayCardNo = 5239-****-****-9001 &
+CardExpire = 205012312400 &
+EncodingType = UTF8 &
+RtnUrlEncUse = Y
+
+### 네이버페이 결제 수단 등록 (정기/반복결제 등록 번호 발급)
+GET {{host}}/payment/naverpay/register-recurrent-payment-callback?resultCode=Success&reservedId=1234567890&tempReceiptId=abcdefg&recurrentId=recurrent12345&userEmail=e-tap@naver.com
+
+### 대표 결제 수단 변경
+POST {{host}}/payments/10/set-primary
+Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/zerobase/zbcharger/configuration/querydsl/QuerydslConfiguration.java
+++ b/src/main/java/com/zerobase/zbcharger/configuration/querydsl/QuerydslConfiguration.java
@@ -1,0 +1,19 @@
+package com.zerobase.zbcharger.configuration.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/configuration/security/RequestMatchers.java
+++ b/src/main/java/com/zerobase/zbcharger/configuration/security/RequestMatchers.java
@@ -10,6 +10,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 public final class RequestMatchers {
 
     private static final String[] PERMIT_ALL_WHITELIST = {
+        "/smartropay/**",
         "/members/register",
         "/member/email/verify",
         "/auth/token",

--- a/src/main/java/com/zerobase/zbcharger/configuration/security/RequestMatchers.java
+++ b/src/main/java/com/zerobase/zbcharger/configuration/security/RequestMatchers.java
@@ -10,7 +10,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 public final class RequestMatchers {
 
     private static final String[] PERMIT_ALL_WHITELIST = {
-        "/smartropay/**",
+        "/payment/**",
         "/members/register",
         "/member/email/verify",
         "/auth/token",

--- a/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Charger.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Charger.java
@@ -93,6 +93,7 @@ public class Charger extends AuditableEntity implements Persistable<String> {
     private final String deleteDetail;
 
     @Transient
+    @Builder.Default
     private boolean isNew = true;
 
     @Override

--- a/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Company.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Company.java
@@ -47,6 +47,7 @@ public class Company extends AuditableEntity implements Persistable<String> {
     private final String operator;
 
     @Transient
+    @Builder.Default
     private boolean isNew = true;
 
     @Override

--- a/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Station.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/charger/entity/Station.java
@@ -113,6 +113,7 @@ public class Station extends AuditableEntity implements Persistable<String> {
     private final Double longitude;
 
     @Transient
+    @Builder.Default
     private boolean isNew = true;
 
     @Override

--- a/src/main/java/com/zerobase/zbcharger/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/member/dao/MemberRepository.java
@@ -3,6 +3,7 @@ package com.zerobase.zbcharger.domain.member.dao;
 import com.zerobase.zbcharger.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +12,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
+
+    @Query("select m.id from Member m where m.email = :email")
+    Optional<Long> findIdByEmail(String email);
 }

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/NaverPayApi.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/NaverPayApi.java
@@ -1,0 +1,49 @@
+package com.zerobase.zbcharger.domain.payment.api.naver;
+
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.ApprovalRecurrentRegistrationResponseBody;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.NaverPayResponse;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.SearchRegisteredRecurrentRequest;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.SearchRegisteredRecurrentResponseBody;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.service.annotation.PostExchange;
+
+/**
+ * 네이버페이 API proxy 인터페이스
+ */
+public interface NaverPayApi {
+
+    /**
+     * 정기/반복결제 등록 완료
+     *
+     * @param clientId       클라이언트 아이디
+     * @param clientSecret   클라이언트 시크릿
+     * @param chainId        체인 아이디
+     * @param idempotencyKey API 멱등성 키
+     * @param reserveId      등록 예약 번호
+     * @param tempReceiptId  임시 접수 번호
+     */
+    @PostExchange("/naverpay-partner/naverpay/payments/recurrent/regist/v1/approval")
+    NaverPayResponse<ApprovalRecurrentRegistrationResponseBody> approvalRecurrentRegistration(
+        @RequestHeader("X-Naver-Client-Id") String clientId,
+        @RequestHeader("X-Naver-Client_Secret") String clientSecret,
+        @RequestHeader("X-NaverPay-Chain-Id") String chainId,
+        @RequestHeader("X-NaverPay-Idempotency-Key") String idempotencyKey,
+        @RequestBody String reserveId,
+        @RequestBody String tempReceiptId);
+
+    /**
+     * 등록된 정기/반복결제 조회
+     *
+     * @param clientId     클라이언트 아이디
+     * @param clientSecret 클라이언트 시크릿
+     * @param chainId      체인 아이디
+     * @param request      요청
+     */
+    @PostExchange("/naverpay-partner/naverpay/payments/recurrent/v1/list")
+    NaverPayResponse<SearchRegisteredRecurrentResponseBody> getRegisteredRecurrentList(
+        @RequestHeader("X-Naver-Client-Id") String clientId,
+        @RequestHeader("X-Naver-Client_Secret") String clientSecret,
+        @RequestHeader("X-NaverPay-Chain-Id") String chainId,
+        @RequestBody SearchRegisteredRecurrentRequest request);
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/ApprovalRecurrentRegistrationResponseBody.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/ApprovalRecurrentRegistrationResponseBody.java
@@ -1,0 +1,16 @@
+package com.zerobase.zbcharger.domain.payment.api.naver.dto;
+
+/**
+ * 정기/반복 결제 완료 응답 바디
+ *
+ * @param reserveId      등록 예약 번호
+ * @param tempReceiptId  임시 접수 번호
+ * @param recurrentId    정기/반복결제 등록 번호
+ * @param actionType     등록 예약 시 가맹점이 전달한 actionType
+ * @param preRecurrentId actionType이 "CHANGE"인 경우 변경되기 전 정기/반복결제 등록 번호
+ */
+public record ApprovalRecurrentRegistrationResponseBody(String reserveId, String tempReceiptId,
+                                                        String recurrentId, String actionType,
+                                                        String preRecurrentId) {
+
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/NaverPayResponse.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/NaverPayResponse.java
@@ -1,0 +1,18 @@
+package com.zerobase.zbcharger.domain.payment.api.naver.dto;
+
+import static com.zerobase.zbcharger.domain.payment.api.naver.dto.constant.NaverPayApiResponseCode.SUCCESS;
+
+/**
+ * 네이버페이 API 응답
+ *
+ * @param <T>     바디 타입
+ * @param code    응답 코드
+ * @param message 응답 메시지
+ * @param body    응답 바디
+ */
+public record NaverPayResponse<T>(String code, String message, T body) {
+
+    public boolean isSuccess() {
+        return SUCCESS.getValue().equals(code);
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/Recurrent.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/Recurrent.java
@@ -1,0 +1,17 @@
+package com.zerobase.zbcharger.domain.payment.api.naver.dto;
+
+/**
+ * 정기/반복 결제 정보
+ *
+ * @param recurrentId           정기/반복 결제 등록 번호
+ * @param productCode           상품 코드
+ * @param naverPointUse         네이버페이 포인트 사용 여부
+ * @param primaryPayMeans       결제 수단
+ * @param primaryPayMeansCorpCd 결제 수단 회사 코드
+ * @param primaryPayMeansNo     결제 수단 번호
+ */
+public record Recurrent(String recurrentId, String productCode, String naverPointUse,
+                        String primaryPayMeans, String primaryPayMeansCorpCd,
+                        String primaryPayMeansNo) {
+
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/SearchRegisteredRecurrentRequest.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/SearchRegisteredRecurrentRequest.java
@@ -1,0 +1,23 @@
+package com.zerobase.zbcharger.domain.payment.api.naver.dto;
+
+import lombok.Builder;
+
+/**
+ * 정기/반복 결제 정보 조회 요청
+ *
+ * @param recurrentId 정기/반복 결제 등록 번호
+ * @param startTime   등록 시작 일시(YYYYMMDDHH24MMSS)
+ * @param endTime     등록 종료 일시(YYYYMMDDHH24MMSS)
+ * @param state       VALID: 유효, EXPIRED: 만료, ALL: 전체
+ * @param pageNumber  조회하고자 하는 페이지번호, default: 1
+ * @param rowsPerPage 페이지 당 row 건수(1~100), default: 20
+ */
+@Builder
+public record SearchRegisteredRecurrentRequest(String recurrentId,
+                                               String startTime,
+                                               String endTime,
+                                               String state,
+                                               int pageNumber,
+                                               int rowsPerPage) {
+
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/SearchRegisteredRecurrentResponseBody.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/SearchRegisteredRecurrentResponseBody.java
@@ -1,0 +1,16 @@
+package com.zerobase.zbcharger.domain.payment.api.naver.dto;
+
+/**
+ * 정기/반복 결제 정보 조회 응답 바디
+ *
+ * @param list               정기/반복 결제 정보 목록
+ * @param totalCount         전체 건수
+ * @param totalResponseCount 응답 건수
+ * @param totalPageCount     전체 페이지 수
+ * @param currentPageNumber  현재 페이지 번호
+ */
+public record SearchRegisteredRecurrentResponseBody(Recurrent[] list, int totalCount,
+                                                    int totalResponseCount, int totalPageCount,
+                                                    int currentPageNumber) {
+
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/constant/NaverPayApiResponseCode.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/dto/constant/NaverPayApiResponseCode.java
@@ -1,0 +1,29 @@
+package com.zerobase.zbcharger.domain.payment.api.naver.dto.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 네이버페이 API 응답 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum NaverPayApiResponseCode {
+
+    /**
+     * 성공
+     */
+    SUCCESS("Success"),
+
+    /**
+     * 유효하지 않은 가맹점
+     */
+    INVALID_MERCHANT("InvalidMerchant"),
+
+    /**
+     * 서비스 점검중
+     */
+    MAINTENANCE_ONGOING("MaintenanceOngoing");
+
+    private final String value;
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/impl/MockNaverPayApiImpl.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/impl/MockNaverPayApiImpl.java
@@ -1,0 +1,49 @@
+package com.zerobase.zbcharger.domain.payment.api.naver.impl;
+
+import static com.zerobase.zbcharger.domain.payment.api.naver.dto.constant.NaverPayApiResponseCode.SUCCESS;
+
+import com.zerobase.zbcharger.domain.payment.api.naver.NaverPayApi;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.ApprovalRecurrentRegistrationResponseBody;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.NaverPayResponse;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.Recurrent;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.SearchRegisteredRecurrentRequest;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.SearchRegisteredRecurrentResponseBody;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+/**
+ * 네이버페이 API Mock
+ */
+@Component
+public class MockNaverPayApiImpl implements NaverPayApi {
+
+    @Override
+    public NaverPayResponse<ApprovalRecurrentRegistrationResponseBody> approvalRecurrentRegistration(
+        String clientId, String clientSecret, String chainId, String idempotencyKey,
+        String reserveId, String tempReceiptId) {
+        return new NaverPayResponse<>(SUCCESS.getValue(), null,
+            new ApprovalRecurrentRegistrationResponseBody(
+                reserveId,
+                tempReceiptId,
+                UUID.randomUUID().toString(),
+                "ACTION",
+                null));
+    }
+
+    @Override
+    public NaverPayResponse<SearchRegisteredRecurrentResponseBody> getRegisteredRecurrentList(
+        String clientId, String clientSecret, String chainId,
+        SearchRegisteredRecurrentRequest request) {
+        return new NaverPayResponse<>(SUCCESS.getValue(), null,
+            new SearchRegisteredRecurrentResponseBody(new Recurrent[]{
+                new Recurrent(
+                    request.recurrentId(),
+                    "PRODUCT_CODE",
+                    "Y",
+                    "CARD",
+                    "11",
+                    "5239-****-****-9001"
+                )
+            }, 1, 1, 1, 1));
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/impl/MockNaverPayApiImpl.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/api/naver/impl/MockNaverPayApiImpl.java
@@ -8,7 +8,6 @@ import com.zerobase.zbcharger.domain.payment.api.naver.dto.NaverPayResponse;
 import com.zerobase.zbcharger.domain.payment.api.naver.dto.Recurrent;
 import com.zerobase.zbcharger.domain.payment.api.naver.dto.SearchRegisteredRecurrentRequest;
 import com.zerobase.zbcharger.domain.payment.api.naver.dto.SearchRegisteredRecurrentResponseBody;
-import java.util.UUID;
 import org.springframework.stereotype.Component;
 
 /**
@@ -25,7 +24,7 @@ public class MockNaverPayApiImpl implements NaverPayApi {
             new ApprovalRecurrentRegistrationResponseBody(
                 reserveId,
                 tempReceiptId,
-                UUID.randomUUID().toString(),
+                "RECURRENT_ID:" + reserveId,
                 "ACTION",
                 null));
     }

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/controller/NaverPayController.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/controller/NaverPayController.java
@@ -1,0 +1,23 @@
+package com.zerobase.zbcharger.domain.payment.controller;
+
+import com.zerobase.zbcharger.domain.payment.service.naver.RegisterNaverPayService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class NaverPayController {
+
+    private final RegisterNaverPayService registerNaverPayService;
+
+    /**
+     * 정기/반복 결제 등록 콜백
+     */
+    @GetMapping("payment/naverpay/register-recurrent-payment-callback")
+    public void registerRecurrentPaymentCallback(@RequestParam Map<String, String> params) {
+        registerNaverPayService.registerPaymentMethod(params);
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/controller/PaymentController.java
@@ -1,0 +1,21 @@
+package com.zerobase.zbcharger.domain.payment.controller;
+
+import com.zerobase.zbcharger.configuration.security.annotation.CurrentUser;
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.domain.payment.service.PaymentMethodService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentMethodService paymentMethodService;
+
+    @PostMapping("/payments/{id}/set-primary")
+    public void setPrimaryPaymentMethod(@PathVariable Long id, @CurrentUser Member member) {
+        paymentMethodService.setPrimaryPaymentMethod(id, member);
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/controller/SmartroPayController.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/controller/SmartroPayController.java
@@ -1,0 +1,29 @@
+package com.zerobase.zbcharger.domain.payment.controller;
+
+import com.zerobase.zbcharger.domain.payment.service.smartro.RegisterSmartroPayService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 스마트로 페이 연동 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+public class SmartroPayController {
+
+    private final RegisterSmartroPayService registerSmartroPayService;
+
+    /**
+     * 스마트로 페이 빌링 키 발급 콜백
+     */
+    @PostMapping("/smartropay/issue-billing-callback")
+    public ResponseEntity<Void> issueBillingKeyCallback(@RequestParam Map<String, String> params) {
+        registerSmartroPayService.registerPaymentMethod(params);
+        // TODO: redirect
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/controller/SmartroPayController.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/controller/SmartroPayController.java
@@ -3,7 +3,6 @@ package com.zerobase.zbcharger.domain.payment.controller;
 import com.zerobase.zbcharger.domain.payment.service.smartro.RegisterSmartroPayService;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,10 +19,9 @@ public class SmartroPayController {
     /**
      * 스마트로 페이 빌링 키 발급 콜백
      */
-    @PostMapping("/smartropay/issue-billing-callback")
-    public ResponseEntity<Void> issueBillingKeyCallback(@RequestParam Map<String, String> params) {
+    @PostMapping("payment/smartropay/issue-billing-callback")
+    public void issueBillingKeyCallback(@RequestParam Map<String, String> params) {
         registerSmartroPayService.registerPaymentMethod(params);
         // TODO: redirect
-        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dao/PaymentMethodRepository.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dao/PaymentMethodRepository.java
@@ -1,11 +1,13 @@
 package com.zerobase.zbcharger.domain.payment.dao;
 
+import com.zerobase.zbcharger.domain.payment.dao.custom.CustomPaymentMethodRepository;
 import com.zerobase.zbcharger.domain.payment.entity.PaymentMethod;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PaymentMethodRepository extends JpaRepository<PaymentMethod, Long> {
+public interface PaymentMethodRepository extends JpaRepository<PaymentMethod, Long>,
+    CustomPaymentMethodRepository {
 
     Long countByMemberId(Long memberId);
 }

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dao/PaymentMethodRepository.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dao/PaymentMethodRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.zbcharger.domain.payment.dao;
+
+import com.zerobase.zbcharger.domain.payment.entity.PaymentMethod;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentMethodRepository extends JpaRepository<PaymentMethod, Long> {
+
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dao/PaymentMethodRepository.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dao/PaymentMethodRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PaymentMethodRepository extends JpaRepository<PaymentMethod, Long> {
 
+    Long countByMemberId(Long memberId);
 }

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dao/custom/CustomPaymentMethodRepository.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dao/custom/CustomPaymentMethodRepository.java
@@ -1,0 +1,9 @@
+package com.zerobase.zbcharger.domain.payment.dao.custom;
+
+import com.zerobase.zbcharger.domain.payment.entity.PaymentMethod;
+import java.util.Optional;
+
+public interface CustomPaymentMethodRepository {
+
+    Optional<PaymentMethod> findPrimaryPaymentMethodByMemberId(Long memberId);
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dao/custom/impl/CustomPaymentMethodRepositoryImpl.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dao/custom/impl/CustomPaymentMethodRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.zerobase.zbcharger.domain.payment.dao.custom.impl;
+
+import static com.zerobase.zbcharger.domain.payment.entity.QPaymentMethod.paymentMethod;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerobase.zbcharger.domain.payment.dao.custom.CustomPaymentMethodRepository;
+import com.zerobase.zbcharger.domain.payment.entity.PaymentMethod;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomPaymentMethodRepositoryImpl implements CustomPaymentMethodRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<PaymentMethod> findPrimaryPaymentMethodByMemberId(Long memberId) {
+        return Optional.ofNullable(
+            queryFactory.select(paymentMethod)
+                .from(paymentMethod)
+                .where(paymentMethod.memberId.eq(memberId)
+                    .and(paymentMethod.isPrimary.eq(true)))
+                .fetchOne());
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dto/NaverPayCallback.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dto/NaverPayCallback.java
@@ -1,0 +1,26 @@
+package com.zerobase.zbcharger.domain.payment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NaverPayCallback extends RegisterPaymentCallback {
+
+    private final String resultCode;
+    private final String resultMessage;
+    private final String reserveId;
+    private final String tempReceiptId;
+    private final String recurrentId;
+    private final String userEmail;
+
+    @Builder
+    public NaverPayCallback(String resultCode, String resultMessage, String reserveId,
+        String tempReceiptId, String recurrentId, String userEmail) {
+        this.resultCode = resultCode;
+        this.resultMessage = resultMessage;
+        this.reserveId = reserveId;
+        this.tempReceiptId = tempReceiptId;
+        this.recurrentId = recurrentId;
+        this.userEmail = userEmail;
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dto/NaverPayCallback.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dto/NaverPayCallback.java
@@ -3,6 +3,9 @@ package com.zerobase.zbcharger.domain.payment.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * 네이버페이 결제 콜백 DTO
+ */
 @Getter
 public class NaverPayCallback extends RegisterPaymentCallback {
 
@@ -14,8 +17,9 @@ public class NaverPayCallback extends RegisterPaymentCallback {
     private final String userEmail;
 
     @Builder
-    public NaverPayCallback(String resultCode, String resultMessage, String reserveId,
-        String tempReceiptId, String recurrentId, String userEmail) {
+    public NaverPayCallback(Long memberId, String resultCode, String resultMessage,
+        String reserveId, String tempReceiptId, String recurrentId, String userEmail) {
+        super(memberId);
         this.resultCode = resultCode;
         this.resultMessage = resultMessage;
         this.reserveId = reserveId;

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dto/RegisterPaymentCallback.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dto/RegisterPaymentCallback.java
@@ -1,0 +1,5 @@
+package com.zerobase.zbcharger.domain.payment.dto;
+
+public abstract class RegisterPaymentCallback {
+
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dto/RegisterPaymentCallback.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dto/RegisterPaymentCallback.java
@@ -1,5 +1,19 @@
 package com.zerobase.zbcharger.domain.payment.dto;
 
+import lombok.Getter;
+
+/**
+ * 결제 콜백 공통 DTO
+ */
+@Getter
 public abstract class RegisterPaymentCallback {
 
+    /**
+     * 회원 아이디
+     */
+    private final Long memberId;
+
+    protected RegisterPaymentCallback(Long memberId) {
+        this.memberId = memberId;
+    }
 }

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dto/SmartroPayCallback.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dto/SmartroPayCallback.java
@@ -1,0 +1,48 @@
+package com.zerobase.zbcharger.domain.payment.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SmartroPayCallback extends RegisterPaymentCallback {
+
+    private final String payMethod;
+    private final String merchantId;
+    private final String orderId;
+    private final String transactionId;
+    private final String billTokenKey;
+    private final String mallUserId;
+    private final String resultCode;
+    private final String resultMessage;
+    private final String verifyValue;
+    private final String issuerCardCode;
+    private final String issuerCardName;
+    private final String displayCardNumber;
+    private final LocalDateTime cardExpire;
+    private final String encodingType;
+    private final boolean returnUrlEncodingUse;
+
+    @Builder
+    public SmartroPayCallback(String payMethod, String merchantId, String orderId,
+        String transactionId, String billTokenKey, String mallUserId, String resultCode,
+        String resultMessage, String verifyValue, String issuerCardCode, String issuerCardName,
+        String displayCardNumber, LocalDateTime cardExpire, String encodingType,
+        boolean returnUrlEncodingUse) {
+        this.payMethod = payMethod;
+        this.merchantId = merchantId;
+        this.orderId = orderId;
+        this.transactionId = transactionId;
+        this.billTokenKey = billTokenKey;
+        this.mallUserId = mallUserId;
+        this.resultCode = resultCode;
+        this.resultMessage = resultMessage;
+        this.verifyValue = verifyValue;
+        this.issuerCardCode = issuerCardCode;
+        this.issuerCardName = issuerCardName;
+        this.displayCardNumber = displayCardNumber;
+        this.cardExpire = cardExpire;
+        this.encodingType = encodingType;
+        this.returnUrlEncodingUse = returnUrlEncodingUse;
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/dto/SmartroPayCallback.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/dto/SmartroPayCallback.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * 스마트로페이 결제 콜백 DTO
+ */
 @Getter
 public class SmartroPayCallback extends RegisterPaymentCallback {
 
@@ -12,7 +15,6 @@ public class SmartroPayCallback extends RegisterPaymentCallback {
     private final String orderId;
     private final String transactionId;
     private final String billTokenKey;
-    private final String mallUserId;
     private final String resultCode;
     private final String resultMessage;
     private final String verifyValue;
@@ -29,12 +31,12 @@ public class SmartroPayCallback extends RegisterPaymentCallback {
         String resultMessage, String verifyValue, String issuerCardCode, String issuerCardName,
         String displayCardNumber, LocalDateTime cardExpire, String encodingType,
         boolean returnUrlEncodingUse) {
+        super(Long.parseLong(mallUserId));
         this.payMethod = payMethod;
         this.merchantId = merchantId;
         this.orderId = orderId;
         this.transactionId = transactionId;
         this.billTokenKey = billTokenKey;
-        this.mallUserId = mallUserId;
         this.resultCode = resultCode;
         this.resultMessage = resultMessage;
         this.verifyValue = verifyValue;

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/entity/NaverPay.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/entity/NaverPay.java
@@ -4,8 +4,10 @@ import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @DiscriminatorValue("NAVER_PAY")
 @NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/entity/NaverPay.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/entity/NaverPay.java
@@ -1,0 +1,51 @@
+package com.zerobase.zbcharger.domain.payment.entity;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("NAVER_PAY")
+@NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)
+public class NaverPay extends PaymentMethod {
+
+    /**
+     * 정식 정기/반복결제 등록 번호
+     */
+    private final String recurrentId;
+
+    // TODO: 상품 코드 정의, 상품 테이블 필요한가?
+    /**
+     * 상품 코드
+     */
+    private final String productCode;
+
+    /**
+     * 주 결제 수단(CARD: 신용카드, BANK: 계좌 이체)
+     */
+    private final String primaryPayMeans;
+
+    // TODO: 카드사/은행 코드 공통 코드로 정의 필요(https://developer.pay.naver.com/docs/v2/api#etc-etc_card)
+    /**
+     * 주 결제 수단 카드사/은행 코드
+     */
+    private final String primaryPayMeansCorpCd;
+
+    /**
+     * 주 결제 수단 번호. 일부 마스킹된 카드/계좌 번호
+     */
+    private final String primaryPayMeansNo;
+
+    @Builder
+    public NaverPay(Long memberId, String recurrentId, String productCode, String primaryPayMeans,
+        String primaryPayMeansCorpCd, String primaryPayMeansNo) {
+        super(memberId, PayMethod.NAVER_PAY);
+        this.recurrentId = recurrentId;
+        this.productCode = productCode;
+        this.primaryPayMeans = primaryPayMeans;
+        this.primaryPayMeansCorpCd = primaryPayMeansCorpCd;
+        this.primaryPayMeansNo = primaryPayMeansNo;
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/entity/PayMethod.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/entity/PayMethod.java
@@ -1,0 +1,6 @@
+package com.zerobase.zbcharger.domain.payment.entity;
+
+public enum PayMethod {
+    CARD,
+    NAVER_PAY,
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/entity/PaymentMethod.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/entity/PaymentMethod.java
@@ -1,0 +1,72 @@
+package com.zerobase.zbcharger.domain.payment.entity;
+
+import com.zerobase.zbcharger.domain.common.entity.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 결제 수단
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "method")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+public class PaymentMethod extends AuditableEntity {
+
+    /**
+     * pk
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 회원 pk
+     */
+    private final Long memberId;
+
+    /**
+     * 기본 결제수단 여부
+     */
+    private boolean isPrimary;
+
+    /**
+     * 결제수단
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(insertable = false, updatable = false)
+    private final PayMethod method;
+
+    public PaymentMethod(Long memberId, PayMethod method) {
+        this.memberId = memberId;
+        this.method = method;
+    }
+
+    /**
+     * 기본 결제수단 여부 설정
+     *
+     * @param isPrimary
+     */
+    public void setPrimary() {
+        this.isPrimary = true;
+    }
+
+    /**
+     * 기본 결제수단 여부 해제
+     */
+    public void unsetPrimary() {
+        this.isPrimary = false;
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/entity/SmartroPay.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/entity/SmartroPay.java
@@ -6,8 +6,10 @@ import jakarta.persistence.Entity;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @DiscriminatorValue("CARD")
 @NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/entity/SmartroPay.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/entity/SmartroPay.java
@@ -1,0 +1,65 @@
+package com.zerobase.zbcharger.domain.payment.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("CARD")
+@NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)
+public class SmartroPay extends PaymentMethod {
+
+    /**
+     * 주문 번호
+     */
+    private final String orderId;
+
+    /**
+     * 거래 아이디
+     */
+    private final String transactionId;
+
+    /**
+     * 빌링키
+     */
+    private final String billTokenKey;
+
+    /**
+     * 카드사 코드
+     */
+    @Column(columnDefinition = "char(2)")
+    private final String issuerCardCode;
+
+    /**
+     * 카드사 이름
+     */
+    private final String issuerCardName;
+
+    /**
+     * 표시용 카드 번호
+     */
+    private final String displayCardNo;
+
+    /**
+     * 빌링키 유효 기간
+     */
+    private final LocalDateTime cardExpire;
+
+    @Builder
+    public SmartroPay(Long memberId, String orderId, String transactionId,
+        String billTokenKey, String issuerCardCode,
+        String issuerCardName, String displayCardNo, LocalDateTime cardExpire) {
+        super(memberId, PayMethod.CARD);
+        this.orderId = orderId;
+        this.transactionId = transactionId;
+        this.billTokenKey = billTokenKey;
+        this.issuerCardCode = issuerCardCode;
+        this.issuerCardName = issuerCardName;
+        this.displayCardNo = displayCardNo;
+        this.cardExpire = cardExpire;
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/exception/RegisterPaymentException.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/exception/RegisterPaymentException.java
@@ -1,0 +1,32 @@
+package com.zerobase.zbcharger.domain.payment.exception;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RegisterPaymentException extends RuntimeException {
+
+    private final Map<String, Object> payload;
+
+    public RegisterPaymentException(String message, Map<String, Object> payload) {
+        super(message);
+        this.payload = payload;
+    }
+
+    public RegisterPaymentException(String message, Throwable cause, Map<String, Object> payload) {
+        super(message, cause);
+        this.payload = payload;
+    }
+
+    public RegisterPaymentException(String message, Throwable cause) {
+        super(message, cause);
+        this.payload = Collections.emptyMap();
+    }
+
+    public String getPayloadKeyValues() {
+        return payload.entrySet()
+            .stream()
+            .map(entry -> entry.getKey() + "=" + entry.getValue())
+            .collect(Collectors.joining(" "));
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/exception/RegisterPaymentException.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/exception/RegisterPaymentException.java
@@ -8,6 +8,11 @@ public class RegisterPaymentException extends RuntimeException {
 
     private final Map<String, Object> payload;
 
+    public RegisterPaymentException(String message) {
+        super(message);
+        this.payload = Collections.emptyMap();
+    }
+
     public RegisterPaymentException(String message, Map<String, Object> payload) {
         super(message);
         this.payload = payload;

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/service/PaymentMethodService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/service/PaymentMethodService.java
@@ -1,0 +1,42 @@
+package com.zerobase.zbcharger.domain.payment.service;
+
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.ACCESS_DENIED;
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.PAYMENT_METHOD_NOT_FOUND;
+
+import com.zerobase.zbcharger.domain.member.entity.Member;
+import com.zerobase.zbcharger.domain.payment.dao.PaymentMethodRepository;
+import com.zerobase.zbcharger.domain.payment.entity.PaymentMethod;
+import com.zerobase.zbcharger.exception.CustomException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentMethodService {
+
+    private final PaymentMethodRepository paymentMethodRepository;
+
+    /**
+     * 기본 결제수단으로 설정
+     *
+     * @param id     결제수단 아이디
+     * @param member 회원
+     */
+    @Transactional
+    public void setPrimaryPaymentMethod(Long id, Member member) {
+        PaymentMethod paymentMethod = paymentMethodRepository.findById(id)
+            .orElseThrow(() -> new CustomException(PAYMENT_METHOD_NOT_FOUND));
+
+        if (!Objects.equals(paymentMethod.getMemberId(), member.getId())) {
+            throw new CustomException(ACCESS_DENIED);
+        }
+
+        // TODO: update 시 왜 member_id가 set 되는지 확인 필요
+        paymentMethodRepository.findPrimaryPaymentMethodByMemberId(member.getId())
+            .ifPresent(PaymentMethod::unsetPrimary);
+
+        paymentMethod.setPrimary();
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/service/RegisterPaymentService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/service/RegisterPaymentService.java
@@ -9,9 +9,19 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 콜백 기반 결제 수단 등록 서비스
+ *
+ * @param <Callback> 콜백 파라미터 타입
+ */
 @Slf4j
 public abstract class RegisterPaymentService<Callback> {
 
+    /**
+     * 결제 수단 등록
+     *
+     * @param params 콜백 파라미터
+     */
     @Transactional
     public void registerPaymentMethod(Map<String, String> params) {
         Callback callback = toPaymentCallback(params);
@@ -24,7 +34,19 @@ public abstract class RegisterPaymentService<Callback> {
         }
     }
 
+    /**
+     * 벤더별 결제 수단 등록 로직
+     *
+     * @param callback 콜백 파라미터
+     * @return 결제 수단
+     */
     protected abstract PaymentMethod registerInternal(Callback callback);
 
+    /**
+     * 콜백 파라미터를 콜백 타입으로 변환
+     *
+     * @param params 콜백 파라미터
+     * @return 콜백 타입
+     */
     protected abstract Callback toPaymentCallback(Map<String, String> params);
 }

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/service/RegisterPaymentService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/service/RegisterPaymentService.java
@@ -1,0 +1,30 @@
+package com.zerobase.zbcharger.domain.payment.service;
+
+import static com.zerobase.zbcharger.exception.constant.ErrorCode.REGISTER_PAYMENT_FAILED;
+
+import com.zerobase.zbcharger.domain.payment.entity.PaymentMethod;
+import com.zerobase.zbcharger.domain.payment.exception.RegisterPaymentException;
+import com.zerobase.zbcharger.exception.CustomException;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+public abstract class RegisterPaymentService<Callback> {
+
+    @Transactional
+    public void registerPaymentMethod(Map<String, String> params) {
+        Callback callback = toPaymentCallback(params);
+
+        try {
+            registerInternal(callback);
+        } catch (RegisterPaymentException e) {
+            log.error("결제 수단 등록 실패: {}, {}", e.getMessage(), e.getPayloadKeyValues(), e);
+            throw new CustomException(REGISTER_PAYMENT_FAILED, e);
+        }
+    }
+
+    protected abstract PaymentMethod registerInternal(Callback callback);
+
+    protected abstract Callback toPaymentCallback(Map<String, String> params);
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/service/RegisterPaymentService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/service/RegisterPaymentService.java
@@ -2,10 +2,12 @@ package com.zerobase.zbcharger.domain.payment.service;
 
 import static com.zerobase.zbcharger.exception.constant.ErrorCode.REGISTER_PAYMENT_FAILED;
 
+import com.zerobase.zbcharger.domain.payment.dao.PaymentMethodRepository;
 import com.zerobase.zbcharger.domain.payment.entity.PaymentMethod;
 import com.zerobase.zbcharger.domain.payment.exception.RegisterPaymentException;
 import com.zerobase.zbcharger.exception.CustomException;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,7 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
  * @param <Callback> 콜백 파라미터 타입
  */
 @Slf4j
+@RequiredArgsConstructor
 public abstract class RegisterPaymentService<Callback> {
+
+    private final PaymentMethodRepository paymentMethodRepository;
 
     /**
      * 결제 수단 등록
@@ -26,21 +31,31 @@ public abstract class RegisterPaymentService<Callback> {
     public void registerPaymentMethod(Map<String, String> params) {
         Callback callback = toPaymentCallback(params);
 
+        PaymentMethod paymentMethod = null;
         try {
-            registerInternal(callback);
+            // 벤더별 결제 수단 생성
+            paymentMethod = createPaymentMethod(callback);
         } catch (RegisterPaymentException e) {
             log.error("결제 수단 등록 실패: {}, {}", e.getMessage(), e.getPayloadKeyValues(), e);
             throw new CustomException(REGISTER_PAYMENT_FAILED, e);
         }
+
+        // 결제 수단이 없으면 기본 결제 수단으로 설정
+        if (paymentMethodRepository.countByMemberId(paymentMethod.getMemberId()) == 0) {
+            paymentMethod.setPrimary();
+        }
+
+        // 저장
+        paymentMethodRepository.save(paymentMethod);
     }
 
     /**
-     * 벤더별 결제 수단 등록 로직
+     * 벤더별 결제 수단 생성 로직
      *
      * @param callback 콜백 파라미터
      * @return 결제 수단
      */
-    protected abstract PaymentMethod registerInternal(Callback callback);
+    protected abstract PaymentMethod createPaymentMethod(Callback callback);
 
     /**
      * 콜백 파라미터를 콜백 타입으로 변환

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/service/naver/IdempotencyKeyGenerator.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/service/naver/IdempotencyKeyGenerator.java
@@ -1,0 +1,12 @@
+package com.zerobase.zbcharger.domain.payment.service.naver;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdempotencyKeyGenerator {
+
+    public String getIdempotencyKey() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/service/naver/RegisterNaverPayService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/service/naver/RegisterNaverPayService.java
@@ -1,0 +1,186 @@
+package com.zerobase.zbcharger.domain.payment.service.naver;
+
+import static com.zerobase.zbcharger.domain.payment.api.naver.dto.constant.NaverPayApiResponseCode.INVALID_MERCHANT;
+import static com.zerobase.zbcharger.domain.payment.api.naver.dto.constant.NaverPayApiResponseCode.MAINTENANCE_ONGOING;
+
+import com.zerobase.zbcharger.domain.member.dao.MemberRepository;
+import com.zerobase.zbcharger.domain.payment.api.naver.NaverPayApi;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.ApprovalRecurrentRegistrationResponseBody;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.NaverPayResponse;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.Recurrent;
+import com.zerobase.zbcharger.domain.payment.api.naver.dto.SearchRegisteredRecurrentRequest;
+import com.zerobase.zbcharger.domain.payment.dao.PaymentMethodRepository;
+import com.zerobase.zbcharger.domain.payment.dto.NaverPayCallback;
+import com.zerobase.zbcharger.domain.payment.entity.NaverPay;
+import com.zerobase.zbcharger.domain.payment.entity.PaymentMethod;
+import com.zerobase.zbcharger.domain.payment.exception.RegisterPaymentException;
+import com.zerobase.zbcharger.domain.payment.service.RegisterPaymentService;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * 네이버페이 정기/반복결제 등록 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RegisterNaverPayService extends RegisterPaymentService<NaverPayCallback> {
+
+    private final static String SUCCESS = "Success";
+
+    private final PaymentMethodRepository paymentMethodRepository;
+    private final MemberRepository memberRepository;
+
+    private final NaverPayApi naverPayApi;
+
+    @Value("${payment.naver.client-id}")
+    private String clientId;
+
+    @Value("${payment.naver.client-secret}")
+    private String clientSecret;
+
+    @Value("${payment.naver.chain-id}")
+    private String chainId;
+
+    @Override
+    protected PaymentMethod registerInternal(NaverPayCallback callback) {
+        isSuccessResult(callback);
+
+        var response = approvalRecurrentRegistration(callback);
+        Recurrent recurrent = getRegisteredRecurrent(response.body().recurrentId());
+
+        long memberId = getMemberId(callback.getUserEmail());
+        NaverPay payment = createNaverPay(response.body().recurrentId(), recurrent, memberId);
+
+        if (paymentMethodRepository.countByMemberId(memberId) == 0) {
+            payment.setPrimary();
+        }
+
+        return paymentMethodRepository.save(payment);
+    }
+
+    @Override
+    protected NaverPayCallback toPaymentCallback(Map<String, String> params) {
+        return NaverPayCallback.builder()
+            .resultCode(params.get("resultCode"))
+            .reserveId(params.get("reserveId"))
+            .resultMessage(params.getOrDefault("resultMessage", null))
+            .tempReceiptId(params.getOrDefault("tempReceiptId", null))
+            .tempReceiptId(params.getOrDefault("recurrentId", null))
+            .userEmail(params.get("userEmail"))
+            .build();
+    }
+
+    /**
+     * 콜백 결과 확인
+     *
+     * @param callback 콜백 파라미터
+     */
+    private void isSuccessResult(NaverPayCallback callback) {
+        if (!SUCCESS.equals(callback.getResultCode())) {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("resultCode", callback.getResultCode());
+            payload.put("resultMessage", callback.getResultMessage());
+            payload.put("reserveId", callback.getReserveId());
+            payload.put("recurrentId", callback.getRecurrentId());
+            throw new RegisterPaymentException("정기/반복결제 등록 요청 실패", payload);
+        }
+    }
+
+    /**
+     * 정기/반복결제 등록 완료 요청
+     *
+     * @param callback
+     * @return
+     */
+    private NaverPayResponse<ApprovalRecurrentRegistrationResponseBody> approvalRecurrentRegistration(
+        NaverPayCallback callback) {
+        var response = naverPayApi.approvalRecurrentRegistration(
+            clientId,
+            clientSecret,
+            chainId,
+            UUID.randomUUID().toString(),
+            callback.getReserveId(),
+            callback.getTempReceiptId());
+
+        isSuccessResultForApprovalRecurrentRegistration(response);
+
+        return response;
+    }
+
+    /**
+     * 정기/반복결제 등록 완료 요청 결과 확인
+     *
+     * @param response 응답
+     */
+    private void isSuccessResultForApprovalRecurrentRegistration(NaverPayResponse<?> response) {
+        if (!response.isSuccess()) {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("code", response.code());
+            payload.put("message", response.message());
+            throw new RegisterPaymentException("정기/반복결제 완료 요청 실패", payload);
+        }
+    }
+
+    /**
+     * 등록된 정기/반복결제 조회
+     *
+     * @param recurrentId 정기/반복결제 등록 번호
+     * @return 정기/반복결제 정보
+     */
+    private Recurrent getRegisteredRecurrent(String recurrentId) {
+        var response = naverPayApi.getRegisteredRecurrentList(
+            clientId,
+            clientSecret,
+            chainId,
+            SearchRegisteredRecurrentRequest.builder()
+                .recurrentId(recurrentId)
+                .build());
+
+        if (INVALID_MERCHANT.getValue().equals(response.code())) {
+            throw new RegisterPaymentException("유효하지 않은 가맹점");
+        }
+
+        if (MAINTENANCE_ONGOING.getValue().equals(response.code())) {
+            // TODO: 서비스 점검 이후 재시도 필요
+            return null;
+        }
+
+        return Arrays.stream(response.body().list())
+            .findFirst()
+            .orElse(null);
+    }
+
+    private Long getMemberId(String mallUserId) {
+        return memberRepository.findIdByEmail(mallUserId).orElseThrow(
+            () -> {
+                Map<String, Object> payload = new HashMap<>();
+                payload.put("mallUserId", mallUserId);
+                return new RegisterPaymentException("존재하지 않는 회원입니다.", payload);
+            });
+    }
+
+    private static NaverPay createNaverPay(String recurrentId, Recurrent recurrent, Long memberId) {
+        if (recurrent == null) {
+            return NaverPay.builder()
+                .recurrentId(recurrentId)
+                .memberId(memberId)
+                .build();
+        }
+
+        return NaverPay.builder()
+            .recurrentId(recurrentId)
+            .memberId(memberId)
+            .productCode(recurrent.productCode())
+            .primaryPayMeans(recurrent.primaryPayMeans())
+            .primaryPayMeansCorpCd(recurrent.primaryPayMeansCorpCd())
+            .primaryPayMeansNo(recurrent.primaryPayMeansNo())
+            .build();
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/domain/payment/service/smartro/RegisterSmartroPayService.java
+++ b/src/main/java/com/zerobase/zbcharger/domain/payment/service/smartro/RegisterSmartroPayService.java
@@ -1,0 +1,156 @@
+package com.zerobase.zbcharger.domain.payment.service.smartro;
+
+import com.zerobase.zbcharger.domain.member.dao.MemberRepository;
+import com.zerobase.zbcharger.domain.payment.dao.PaymentMethodRepository;
+import com.zerobase.zbcharger.domain.payment.dto.SmartroPayCallback;
+import com.zerobase.zbcharger.domain.payment.entity.PaymentMethod;
+import com.zerobase.zbcharger.domain.payment.entity.SmartroPay;
+import com.zerobase.zbcharger.domain.payment.exception.RegisterPaymentException;
+import com.zerobase.zbcharger.domain.payment.service.RegisterPaymentService;
+import com.zerobase.zbcharger.util.AesUtils;
+import com.zerobase.zbcharger.util.ShaUtils;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RegisterSmartroPayService extends RegisterPaymentService<SmartroPayCallback> {
+
+    private static final String SUCCESS = "3001";
+
+    private final PaymentMethodRepository paymentMethodRepository;
+    private final MemberRepository memberRepository;
+
+    @Value("${payment.smartro.merchant-key}")
+    private String merchantKey;
+
+    @Override
+    protected PaymentMethod registerInternal(SmartroPayCallback callback) {
+        isSuccessResult(callback);
+
+        String billTokenKey = decodeBillTokenKey(callback.getBillTokenKey());
+        String verifyValue = generateVerifyValue(billTokenKey, callback);
+        verifyForgery(verifyValue, callback.getVerifyValue());
+
+        Long memberId = getMemberId(callback.getMallUserId());
+
+        SmartroPay payment = SmartroPay.builder()
+            .memberId(memberId)
+            .orderId(callback.getOrderId())
+            .transactionId(callback.getTransactionId())
+            .billTokenKey(billTokenKey)
+            .issuerCardCode(callback.getIssuerCardCode())
+            .issuerCardName(callback.getIssuerCardName())
+            .displayCardNo(callback.getDisplayCardNumber())
+            .cardExpire(callback.getCardExpire())
+            .build();
+
+        if (paymentMethodRepository.countByMemberId(memberId) == 0) {
+            payment.setPrimary();
+        }
+
+        return paymentMethodRepository.save(payment);
+    }
+
+    @Override
+    protected SmartroPayCallback toPaymentCallback(Map<String, String> params) {
+        return SmartroPayCallback.builder()
+            .payMethod(params.get("PayMethod"))
+            .merchantId(params.get("Mid"))
+            .orderId(params.get("Moid"))
+            .transactionId(params.get("Tid"))
+            .billTokenKey(params.get("BillTokenKey"))
+            .mallUserId(params.get("MallUserId"))
+            .resultCode(params.get("ResultCode"))
+            .resultMessage(params.get("ResultMsg"))
+            .verifyValue(params.get("VerifyValue"))
+            .issuerCardCode(params.get("IssuerCardCd"))
+            .issuerCardName(params.get("IssuerCardNm"))
+            .displayCardNumber(params.get("DisplayCardNo"))
+            .cardExpire(LocalDateTime.parse(params.get("CardExpire"),
+                DateTimeFormatter.ofPattern("yyyyMMddHHmm")))
+            .encodingType(params.get("EncodingType"))
+            .returnUrlEncodingUse("Y".equals(params.get("RtnUrlEncUse")))
+            .build();
+    }
+
+    /**
+     * 콜백 결과 확인
+     *
+     * @param callback 콜백 파라미터
+     */
+    private void isSuccessResult(SmartroPayCallback callback) {
+        if (!SUCCESS.equals(callback.getResultCode())) {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("resultCode", callback.getResultCode());
+            payload.put("resultMessage", callback.getResultMessage());
+            throw new RegisterPaymentException("빌링키 발급 요청 실패", payload);
+        }
+    }
+
+    /**
+     * 빌링키 복호화
+     *
+     * @param billTokenKey 암호화된 빌링키
+     * @return 복호화된 빌링키
+     */
+    private String decodeBillTokenKey(String billTokenKey) {
+        String mKey = merchantKey.substring(0, 32);
+        try {
+            return AesUtils.decrypt(billTokenKey, mKey);
+        } catch (Exception e) {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("billTokenKey", billTokenKey);
+            payload.put("merchantKey", merchantKey);
+            throw new RegisterPaymentException("빌링키 복호화 실패", e, payload);
+        }
+    }
+
+    /**
+     * 콜백 위변조 검증
+     *
+     * @param generatedVerifiedValue 생성된 위변조 값
+     * @param callbackVerifyValue    콜백에서 전달받은 위변조 값
+     */
+    private void verifyForgery(String generatedVerifiedValue, String callbackVerifyValue) {
+        if (!generatedVerifiedValue.equals(callbackVerifyValue)) {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("generatedVerifiedValue", generatedVerifiedValue);
+            payload.put("callbackVerifyValue", callbackVerifyValue);
+            throw new RegisterPaymentException("위변조 검증 실패", payload);
+        }
+    }
+
+    /**
+     * 위변조 검증 값 생성
+     *
+     * @param billTokenKey 복호화된 빌링키
+     * @param callback     콜백 파라미터
+     * @return 생성된 위변조 값
+     */
+    private String generateVerifyValue(String billTokenKey, SmartroPayCallback callback) {
+        try {
+            return ShaUtils.sha256Base64(
+                callback.getMerchantId() + billTokenKey + callback.getDisplayCardNumber()
+                    + callback.getResultCode() + "SMARTRO!@#");
+        } catch (Exception e) {
+            throw new RegisterPaymentException("위변조 검증 값 생성 실패", e);
+        }
+    }
+
+    private Long getMemberId(String mallUserId) {
+        return memberRepository.findIdByEmail(mallUserId).orElseThrow(
+            () -> {
+                Map<String, Object> payload = new HashMap<>();
+                payload.put("mallUserId", mallUserId);
+                return new RegisterPaymentException("존재하지 않는 회원입니다.", payload);
+            });
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/exception/CustomException.java
+++ b/src/main/java/com/zerobase/zbcharger/exception/CustomException.java
@@ -9,4 +9,9 @@ import lombok.RequiredArgsConstructor;
 public class CustomException extends RuntimeException {
 
     private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/zerobase/zbcharger/exception/constant/ErrorCode.java
+++ b/src/main/java/com/zerobase/zbcharger/exception/constant/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
     ONLY_PHYSICAL_CARD_COULD_REGISTER(BAD_REQUEST, "물리 카드만 등록할 수 있습니다."),
     ACCESS_DENIED(FORBIDDEN, "접근 권한이 없습니다."),
 
+    PAYMENT_METHOD_NOT_FOUND(NOT_FOUND, "결제 수단을 찾을 수 없습니다."),
+
     EMAIL_ALREADY_EXISTS(CONFLICT, "중복되는 메일이 존재합니다."),
 
     EMAIL_VERIFICATION_NOT_FOUND(NOT_FOUND, "이메일 인증 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/zerobase/zbcharger/exception/constant/ErrorCode.java
+++ b/src/main/java/com/zerobase/zbcharger/exception/constant/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     EMAIL_VERIFICATION_RESEND_TIME_EXCEED(BAD_REQUEST, "인증 메일 재전송 가능시간을 초과했습니다. 잠시후 다시 시도하세요."),
     ARGUMENT_NOT_VALID(BAD_REQUEST, "잘못된 입력입니다."),
 
+    REGISTER_PAYMENT_FAILED(INTERNAL_SERVER_ERROR, "결제 수단 등록에 실패했습니다."),
     UNHANDLED_ERROR(INTERNAL_SERVER_ERROR, "정의되지 않은 에러 발생");
 
     /**

--- a/src/main/java/com/zerobase/zbcharger/util/AesUtils.java
+++ b/src/main/java/com/zerobase/zbcharger/util/AesUtils.java
@@ -1,0 +1,34 @@
+package com.zerobase.zbcharger.util;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import jodd.util.Base64;
+
+public final class AesUtils {
+
+    private final static byte[] IV_BYTES = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+    private final static AlgorithmParameterSpec IV_SPEC = new IvParameterSpec(IV_BYTES);
+
+    public static String encrypt(String plainText, String key) throws Exception {
+        byte[] textBytes = plainText.getBytes(UTF_8);
+        SecretKeySpec newKey = new SecretKeySpec(key.getBytes(UTF_8), "AES");
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(Cipher.ENCRYPT_MODE, newKey, IV_SPEC);
+        return Base64.encodeToString(cipher.doFinal(textBytes));
+    }
+
+    public static String decrypt(String cipherText, String key) throws Exception {
+        byte[] textBytes = Base64.decode(cipherText);
+        SecretKeySpec newKey = new SecretKeySpec(key.getBytes(UTF_8), "AES");
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(Cipher.DECRYPT_MODE, newKey, IV_SPEC);
+        return new String(cipher.doFinal(textBytes), UTF_8);
+    }
+}

--- a/src/main/java/com/zerobase/zbcharger/util/ShaUtils.java
+++ b/src/main/java/com/zerobase/zbcharger/util/ShaUtils.java
@@ -1,0 +1,13 @@
+package com.zerobase.zbcharger.util;
+
+import java.security.MessageDigest;
+import org.apache.tomcat.util.codec.binary.Base64;
+
+public final class ShaUtils {
+
+    public static String sha256Base64(String plainText) throws Exception {
+        MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+        messageDigest.update(plainText.getBytes());
+        return Base64.encodeBase64String(messageDigest.digest());
+    }
+}

--- a/src/main/resources/application-payment.yml
+++ b/src/main/resources/application-payment.yml
@@ -1,0 +1,3 @@
+payment:
+  smartro:
+    merchant-key: abcdefghijklmnopqrstuvwxyz1234567890

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ logging.level:
 
 spring:
   profiles:
-    include: email, datagokr
+    include: email, datagokr, payment
 
   datasource:
     url: jdbc:mariadb://localhost/zbcharger?characterEncoding=utf8&serverTimezone=asia/seoul
@@ -18,7 +18,7 @@ spring:
       ddl-auto: validate
     properties:
       hibernate:
-        #        show_sql: true
+        show_sql: true
         format_sql: true
         # batch 정렬 옵션
         order_inserts: true

--- a/src/test/java/com/zerobase/zbcharger/domain/payment/service/RegisterPaymentServiceTest.java
+++ b/src/test/java/com/zerobase/zbcharger/domain/payment/service/RegisterPaymentServiceTest.java
@@ -1,0 +1,136 @@
+package com.zerobase.zbcharger.domain.payment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.zerobase.zbcharger.domain.payment.dao.PaymentMethodRepository;
+import com.zerobase.zbcharger.domain.payment.entity.NaverPay;
+import com.zerobase.zbcharger.domain.payment.entity.PaymentMethod;
+import com.zerobase.zbcharger.domain.payment.entity.SmartroPay;
+import com.zerobase.zbcharger.domain.payment.service.naver.RegisterNaverPayService;
+import com.zerobase.zbcharger.domain.payment.service.smartro.RegisterSmartroPayService;
+import com.zerobase.zbcharger.exception.CustomException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+class RegisterPaymentServiceTest {
+
+    @Autowired
+    private PaymentMethodRepository paymentMethodRepository;
+
+    @Autowired
+    private RegisterNaverPayService registerNaverPayService;
+
+    @Autowired
+    private RegisterSmartroPayService registerSmartroPayService;
+
+    @Test
+    @DisplayName("네이버페이 정기/반복결제 등록 성공")
+    @Transactional
+    void successRegisterNaverPaymentMethod() {
+        // given
+        String reserveId = "reserveId";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("resultCode", "Success");
+        params.put("reserveId", reserveId);
+        params.put("tempReceiptId", "tempReceiptId");
+
+        // when
+        registerNaverPayService.registerPaymentMethod(params);
+        PaymentMethod paymentMethod = paymentMethodRepository.findAll().get(0);
+
+        // then
+        assertInstanceOf(NaverPay.class, paymentMethod);
+        assertEquals("RECURRENT_ID:reserveId", ((NaverPay) paymentMethod).getRecurrentId());
+    }
+
+    @Test
+    @DisplayName("네이버페이 정기/반복결제 등록 실패")
+    @Transactional
+    void failRegisterNaverPaymentMethod() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("resultCode", "fail");
+
+        // when
+        // then
+        assertThrows(CustomException.class,
+            () -> registerNaverPayService.registerPaymentMethod(params));
+    }
+
+    @Test
+    @DisplayName("스마트로 페이 정기/반복결제 등록 성공")
+    @Transactional
+    void successRegisterSmartroPaymentMethod() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("ResultCode", "3001");
+        params.put("ResultMsg", "성공");
+        params.put("PayMethod", "CARD");
+        params.put("Mid", "ZBCharger");
+        params.put("BuyerName", "Lee");
+        params.put("Moid", "orderid");
+        params.put("Tid", "transactionid");
+        params.put("BillTokenKey", "OdoUbgo4EaqxLN9PtmPHIw==");
+        params.put("MallUserId", "0");
+        params.put("MallReserved", "MallReserved");
+        params.put("VerifyValue", "oRdbWkxpttFSESFuN4C329YWuvvLjBGwmW6XgUbo4ts=");
+        params.put("IssuerCardCd", "11");
+        params.put("IssuerCardNm", "땡땡카드");
+        params.put("DisplayCardNo", "5239-****-****-9001");
+        params.put("CardExpire", "205012312400");
+        params.put("EncodingType", "UTF8");
+        params.put("RtnUrlEncUse", "Y");
+
+        // when
+        registerSmartroPayService.registerPaymentMethod(params);
+        PaymentMethod paymentMethod = paymentMethodRepository.findAll().get(0);
+
+        // then
+        assertInstanceOf(SmartroPay.class, paymentMethod);
+        assertEquals("user1billingkey", ((SmartroPay) paymentMethod).getBillTokenKey());
+    }
+
+    @Test
+    @DisplayName("스마트로 페이 정기/반복결제 등록 실패")
+    @Transactional
+    void failRegisterSmartroPaymentMethod() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("ResultCode", "1001");
+        params.put("ResultMsg", "성공");
+        params.put("PayMethod", "CARD");
+        params.put("Mid", "ZBCharger");
+        params.put("BuyerName", "Lee");
+        params.put("Moid", "orderid");
+        params.put("Tid", "transactionid");
+        params.put("BillTokenKey", "OdoUbgo4EaqxLN9PtmPHIw==");
+        params.put("MallUserId", "0");
+        params.put("MallReserved", "MallReserved");
+        params.put("VerifyValue", "oRdbWkxpttFSESFuN4C329YWuvvLjBGwmW6XgUbo4ts=");
+        params.put("IssuerCardCd", "11");
+        params.put("IssuerCardNm", "땡땡카드");
+        params.put("DisplayCardNo", "5239-****-****-9001");
+        params.put("CardExpire", "205012312400");
+        params.put("EncodingType", "UTF8");
+        params.put("RtnUrlEncUse", "Y");
+
+        // when
+        // then
+        assertThrows(CustomException.class,
+            () -> registerSmartroPayService.registerPaymentMethod(params));
+    }
+}

--- a/src/test/java/com/zerobase/zbcharger/util/AesUtilsTest.java
+++ b/src/test/java/com/zerobase/zbcharger/util/AesUtilsTest.java
@@ -1,0 +1,19 @@
+package com.zerobase.zbcharger.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AesUtilsTest {
+
+    @Test
+    @DisplayName("빌링키 암호화")
+    void 빌링키_암호화() {
+        try {
+            System.out.println(
+                AesUtils.encrypt("user1billingkey",
+                    "abcdefghijklmnopqrstuvwxyz1234567890".substring(0, 32)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/zerobase/zbcharger/util/ShaUtilsTest.java
+++ b/src/test/java/com/zerobase/zbcharger/util/ShaUtilsTest.java
@@ -1,0 +1,13 @@
+package com.zerobase.zbcharger.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ShaUtilsTest {
+
+    @Test
+    @DisplayName("SHA256 BASE64")
+    void SHA256_BASE64() throws Exception {
+        System.out.println(ShaUtils.sha256Base64("ZBChargeruser1billingkey5239-****-****-90013001SMARTRO!@#"));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,21 @@
+logging.level:
+  org.hibernate.stat: debug
+  org.hibernate.SQL: debug
+  org.hibernate.orm.jdbc.bind: trace
+
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    database: h2
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: false
+        format_sql: true


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**

***구현 기능***
- 결제 수단 등록
- 결제 수단 조회
- 주 결제 수단 설정

결제 서비스를 연동하기 위해서는 서비스 등록 과정이 필요하기 때문에, 결제 연동 가이드 문서를 보고 가상의 결제 수단 등록 서비스 기능을 구현했습니다.

결제 수단을 최초 한번 등록하고, 발급받은 결제 키로 계속 결제하는 방식이기 때문에 각 제공사의 정기 결제 플로우를 참고해서 구현했습니다.(빨간 박스 영역)
1. 네이버페이 정기/반복 결제(https://developer.pay.naver.com/docs/v2/api#recurrent-recurrent_register_window)
![image](https://github.com/eTaphee/zbcharger/assets/43163409/6eb7a7be-e053-4b0c-9bb3-7ee71319a0b3)
2. 스마트로페이 빌링연동 (https://manual.smartropay.co.kr/billModule.do?level=)
![image](https://github.com/eTaphee/zbcharger/assets/43163409/cf54b959-eed7-4b94-8d9d-835903666b00)

***플로우***
1. 클라이언트 앱 웹뷰(?)에서 제공되는 SDK를 이용하여 사용자의 결제 수단을 입력
2. 서비스사로 부터 발급받은 결제 키를 콜백 요청으로 처리. 유효성 검사 및 추가 정보 획득
3. 결제 키 저장

모바일 앱기준이여서 결제 완료 후 redirect 없이 바로 200 OK에서 끝이납니다.
* 네이버페이의 경우 콜백 이후 키 교환 및 정보 조회하는 프로세스가 필요하여 Exchange 인터페이스를 상속받은 모킹 서비스를 구현했습니다.

***구현 방식***
콜백을 통한 결제수단 등록 과정을 추상화하여, 각 서비스 회사 별 상세 로직을 구현할 수 있도록 설계했습니다.
```java
/**
 * 콜백 기반 결제 수단 등록 서비스
 *
 * @param <Callback> 콜백 파라미터 타입
 */
@Slf4j
@RequiredArgsConstructor
public abstract class RegisterPaymentService<Callback> {

    private final PaymentMethodRepository paymentMethodRepository;

    /**
     * 결제 수단 등록
     *
     * @param params 콜백 파라미터
     */
    @Transactional
    public void registerPaymentMethod(Map<String, String> params) {
        Callback callback = toPaymentCallback(params);

        PaymentMethod paymentMethod = null;
        try {
            // 벤더별 결제 수단 생성
            paymentMethod = createPaymentMethod(callback);
        } catch (RegisterPaymentException e) {
            log.error("결제 수단 등록 실패: {}, {}", e.getMessage(), e.getPayloadKeyValues(), e);
            throw new CustomException(REGISTER_PAYMENT_FAILED, e);
        }

        // 결제 수단이 없으면 기본 결제 수단으로 설정
        if (paymentMethodRepository.countByMemberId(paymentMethod.getMemberId()) == 0) {
            paymentMethod.setPrimary();
        }

        // 저장
        paymentMethodRepository.save(paymentMethod);
    }

    /**
     * 벤더별 결제 수단 생성 로직
     *
     * @param callback 콜백 파라미터
     * @return 결제 수단
     */
    protected abstract PaymentMethod createPaymentMethod(Callback callback);

    /**
     * 콜백 파라미터를 콜백 타입으로 변환
     *
     * @param params 콜백 파라미터
     * @return 콜백 타입
     */
    protected abstract Callback toPaymentCallback(Map<String, String> params);
```

결제수단 별 콜백되는 파라미터(=저장 필드)가 달라서 하나의 테이블로 가는 `SINGLE_TABLE` 방식 대신 `JOIN` 상속 매핑 전략을 이용해서 저장했습니다.
<img width="1065" alt="image" src="https://github.com/eTaphee/zbcharger/assets/43163409/357eaa5e-ffd2-4334-a16e-2aa78d1b3056">

### 질문
1. 특별하게 응답해주는 내용이 없으면 controller의 리턴 타입을 void로 가는데 상관 없나요?
2. 결제 서비스 제공사 별 제공되는 데이터가 다른데, 지금 처럼 JOIN 상속 매핑 전략을 사용해도 괜찮을까요?
아니면, 필요한 정보만을 추려서(결제 키, 카드 마스킹 정보 등..) 하나의 테이블로 가는 SINGLE 상속 매핑 전략을 사용하는게 좋을까요?
3. 콜백 시 요청 데이터들이 너무 많아서 controller에 나열하기에는 너무 많습니다. 그래서 하나의 클래스로 정의해서 입력받으려고 했는데, 스마트로페이같은 경우는 요청 파라미터 이름이 파스칼 케이스로 넘어오더라구요. 그래서 @RequestParam을 했지만 정상적으로 동작하지 않음을 확인했습니다. 그래서 Map<String, Object>를 이용해 데이터를 받고 이걸 변환하는 작업을 수행하는데 괜찮은 방법인가요?
```java
protected abstract Callback toPaymentCallback(Map<String, String> params);
```
4. `RegisterPaymentService` 와 같은 방법은 괜찮은 설계 방식인가요?

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
